### PR TITLE
fix: v3.1.0 -> v3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@carforyou/components",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carforyou/components",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "CAR FOR YOU React components",
   "scripts": {
     "version": "npm run build",


### PR DESCRIPTION
The v3.1.0 release doesn't have the changes from the pre-release v3.1.0-0. My mistake was that before to run the release, I didn't pull the changes into the master. This PR is about getting the changes from the pre-release into this v3.1.1 release

This PR is related to #68 