### PR TITLE
fix: remove tailwind from the index.css

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,7 @@
 import { configure, addDecorator } from "@storybook/react"
 import { withKnobs } from "@storybook/addon-knobs"
+import "../.storybook/stories.css"
+import "../assets/index.css"
 
 const req = require.context("../stories", true, /\.stories\.js$/)
 

--- a/.storybook/stories.css
+++ b/.storybook/stories.css
@@ -1,0 +1,2 @@
+@tailwind base;
+@tailwind utilities;

--- a/assets/index.css
+++ b/assets/index.css
@@ -1,9 +1,5 @@
-@import "tailwindcss/base";
-
+@import "./global.css";
 @import "./customScrollbar.css";
 @import "./pagination.css";
 @import "./input.css";
 @import "./spinner.css";
-@import "./global.css";
-
-@import "tailwindcss/utilities";

--- a/assets/input.css
+++ b/assets/input.css
@@ -11,7 +11,7 @@ input[type=text]:focus {
 }
 
 input[type=text]:hover {
-
+  @apply border-grey-3 transition-2;
 }
 
 input::-webkit-input-placeholder {

--- a/stories/pagination.stories.js
+++ b/stories/pagination.stories.js
@@ -2,9 +2,8 @@ import React from "react"
 import { storiesOf } from "@storybook/react"
 import { action } from "@storybook/addon-actions"
 import { wInfo } from "./utils"
-import Pagination from "../src/components/pagination"
 
-import "../assets/index.css"
+import Pagination from "../src/components/pagination"
 
 storiesOf("Pagination", module)
   .add(


### PR DESCRIPTION
The next release 4.0.0 is depending on the PR's `CAR-2633` in listings and DH projects. Where I've adjusted some changes according to the css files. Otherwise you will see that the stylings are broken. There's not need to revert the next release.