### PR TITLE
fix: removed tailwind imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@carforyou/components",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carforyou/components",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "CAR FOR YOU React components",
   "scripts": {
     "version": "npm run build",


### PR DESCRIPTION
BREAKING CHANGE: The tailwind imports have been removed from the index.css, because we have them in each main.css project.

This release is related to #71 