### PR TITLE
fix: make package tree-shakable

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,10 @@
         }
       ],
       [
-        "@pika/plugin-build-web"
+        "@pika/plugin-build-web",
+        {
+          "entrypoint": "module"
+        }
       ],
       [
         "@pika/plugin-build-node"


### PR DESCRIPTION
our `pkg/package.json` does not contain the `module` entry and therefore does not expose an ESM build, ergo is not tree-shakable.

the docs state this should be added by default. looks like that in the code too - https://github.com/pikapkg/builders/blob/4a28c8f99db4ffe6cfe35b329bd4b4fc84dda411/packages/plugin-build-web/src/index.ts#L19 - maybe a bug?

adding an explicit entrypoint configuration results in `"module": "dist-web/index.js",` as expected