### PR TITLE
CAR-3467-IE: fixed heights in IE

### DIFF
--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -137,7 +137,9 @@ Object {
       "regular": 400,
     },
     "height": Object {
+      "36": "36px",
       "40": "40px",
+      "52": "52px",
       "auto": "auto",
       "full": "100%",
       "screen": "100vh",
@@ -199,8 +201,6 @@ Object {
     },
     "minHeight": Object {
       "0": "0",
-      "36": "36px",
-      "52": "52px",
       "auto": "auto",
       "full": "100%",
       "screen": "100vh",

--- a/src/components/__tests__/__snapshots__/button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Button> button variations renders disabled button 1`] = `
 <div>
   <button
-    class="w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 min-h-52 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon bg-grey-3 border-grey-3 cursor-not-allowed hover:bg-grey-3"
+    class="flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 h-52 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon bg-grey-3 border-grey-3 cursor-not-allowed hover:bg-grey-3"
     disabled=""
     type="button"
   >
@@ -15,7 +15,7 @@ exports[`<Button> button variations renders disabled button 1`] = `
 exports[`<Button> button variations renders small button 1`] = `
 <div>
   <button
-    class="w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 min-h-36 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon"
+    class="flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 h-36 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon"
     type="button"
   >
     Label
@@ -26,7 +26,7 @@ exports[`<Button> button variations renders small button 1`] = `
 exports[`<Button> button variations renders small disabled button 1`] = `
 <div>
   <button
-    class="w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 min-h-36 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon bg-grey-3 border-grey-3 cursor-not-allowed hover:bg-grey-3"
+    class="flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 h-36 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon bg-grey-3 border-grey-3 cursor-not-allowed hover:bg-grey-3"
     disabled=""
     type="button"
   >
@@ -38,7 +38,7 @@ exports[`<Button> button variations renders small disabled button 1`] = `
 exports[`<Button> button variations renders small teal button 1`] = `
 <div>
   <button
-    class="w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 min-h-36 bg-teal border-teal hover:bg-teal-dark focus:bg-teal"
+    class="flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 h-36 bg-teal border-teal hover:bg-teal-dark focus:bg-teal"
     type="button"
   >
     Label
@@ -49,7 +49,7 @@ exports[`<Button> button variations renders small teal button 1`] = `
 exports[`<Button> button variations renders teal button 1`] = `
 <div>
   <button
-    class="w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 min-h-52 bg-teal border-teal hover:bg-teal-dark focus:bg-teal"
+    class="flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 h-52 bg-teal border-teal hover:bg-teal-dark focus:bg-teal"
     type="button"
   >
     Label
@@ -60,7 +60,7 @@ exports[`<Button> button variations renders teal button 1`] = `
 exports[`<Button> button variations renders white Teal button 1`] = `
 <div>
   <button
-    class="w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 min-h-52 bg-white border-teal text-teal hover:opacity-60"
+    class="flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 h-52 bg-white border-teal text-teal hover:opacity-60"
     type="button"
   >
     Label
@@ -71,7 +71,7 @@ exports[`<Button> button variations renders white Teal button 1`] = `
 exports[`<Button> button variations renders white Teal small button 1`] = `
 <div>
   <button
-    class="w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 min-h-36 bg-white border-teal text-teal hover:opacity-60"
+    class="flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 h-36 bg-white border-teal text-teal hover:opacity-60"
     type="button"
   >
     Label
@@ -82,7 +82,7 @@ exports[`<Button> button variations renders white Teal small button 1`] = `
 exports[`<Button> renders default button correctly 1`] = `
 <div>
   <button
-    class="w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 min-h-52 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon"
+    class="flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 h-52 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon"
     type="button"
   >
     Label
@@ -93,7 +93,7 @@ exports[`<Button> renders default button correctly 1`] = `
 exports[`<Button> renders icon, size, paddings and text 1`] = `
 <div>
   <button
-    class="w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 min-h-52 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon"
+    class="flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none px-10 py-5 h-52 bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon"
     type="button"
   >
     <svg

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -27,14 +27,14 @@ export const Button: FC<Props> = ({
   submit,
   icon
 }) => {
-  const padding = classnames("px-10 py-5", small ? "min-h-36" : "min-h-52")
+  const padding = classnames("px-10 py-5", small ? "h-36" : "h-52")
   const { clonedElement, isWrapped } = wrapLink(children, padding)
 
   return (
     <button
       type={submit ? "submit" : "button"}
       className={classnames(
-        "w-12/12 text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none",
+        "flex w-12/12 justify-center items-center text-white leading-xs transition-2 cursor-pointer font-bold text-base rounded border focus:outline-none",
         { [padding]: !isWrapped },
         teal
           ? "bg-teal border-teal hover:bg-teal-dark focus:bg-teal"

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -220,7 +220,9 @@ export default {
       full: "100%",
       screen: "100vh",
       scrollbar: "70px",
-      "40": "40px"
+      "36": "36px",
+      "40": "40px",
+      "52": "52px"
     },
 
     /*
@@ -318,9 +320,7 @@ export default {
       "0": "0",
       auto: "auto",
       full: "100%",
-      screen: "100vh",
-      "36": "36px",
-      "52": "52px"
+      screen: "100vh"
     },
 
     /*


### PR DESCRIPTION
In CSS, you typically choose to use min-height over height to protect yourself from the overflow. 
But in IE 10-11, flex items ignore their parent container’s height if it’s set via the min-height property.

**Approaches** 
1.- Use height instead if possible. Besides, three lines of text are too much for a button.
2.- Check if it's necessary the use from flex otherwise deleted it and use min-height.

**P.D**
Never forget your best friend, IE. It's always behind you : (