### PR TITLE
Fix deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,5 +97,8 @@
         "@pika/plugin-copy-assets"
       ]
     ]
+  },
+  "storybook-deployer": {
+    "commitMessage": "Deploy storybook [skip ci]"
   }
 }


### PR DESCRIPTION
prevents warnings about not having a circle.yml on the gh-pages branch