### PR TITLE
Semantic prereleases include git sha

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,9 +1,12 @@
 // Configuration for semantic-release
 module.exports = {
-  pkgRoot: "pkg",
   branches: [
     "+([0-9])?(.{+([0-9]),x}).x",
     "master",
-    { name: "!(+([0-9])?(.{+([0-9]),x}).x|master)", prerelease: true }
-  ]
+    {
+      name: "!(+([0-9])?(.{+([0-9]),x}).x|master)",
+      prerelease: "${ name }" + `-${process.env.CIRCLE_SHA1}`
+    }
+  ],
+  pkgRoot: "pkg"
 }


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/CAR-3723

amending / force pushing to a branch breaks prereleases. it seems that when the history changes, it does not fetch the tags belonging to now orphaned commits. 

Example:
- fix -> prerelease.1
- fix -> prerelease.2
--- rewrite history to
- fix -> prerelease.1
- fix (amended) -> prerelease.2

semantic release comes up with a version that is actually already existing, but not available in the context of the amended commit that changed history. I understand this is also described in https://github.com/semantic-release/semantic-release/issues/1257 - but they don't plan to fix it

as an alternative, we can append our git sha to the prerelease. no commit will ever have the same sha, so we'll never have conflicts in the published versions, ie. 

```
[8:43:36 AM] [semantic-release] › ✔  Published release 5.5.2-test-prerelease-755fbb4f99da0d119f2b03e6800f88eb1a532a84.1 on test-prerelease channel
```

far from perfect, but the only workaround I can think about. wdyt?