### PR TITLE
fix: no longer purge pseudo selectors on inputs

### DIFF
--- a/assets/input.css
+++ b/assets/input.css
@@ -22,15 +22,6 @@ input:placeholder-shown {
   @apply text-grey-3;
 }
 
-/* hide ie specific input controls */
-/* https://developer.mozilla.org/en-US/docs/Web/CSS/::-ms-clear */
-/* https://developer.mozilla.org/en-US/docs/Web/CSS/::-ms-reveal */
-::-ms-clear,
-::-ms-reveal {
-  width: 0;
-  height: 0;
-}
-
 /* hide step arrows on number inputs */
 input[type="number"] {
   -moz-appearance: textfield;
@@ -43,6 +34,15 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 
 /* hide webkit specific input controls */
-::-webkit-contacts-auto-fill-button {
+input::-webkit-contacts-auto-fill-button {
   visibility: hidden;
+}
+
+/* hide ie specific input controls */
+/* https://developer.mozilla.org/en-US/docs/Web/CSS/::-ms-clear */
+/* https://developer.mozilla.org/en-US/docs/Web/CSS/::-ms-reveal */
+input::-ms-clear,
+input::-ms-reveal {
+  width: 0;
+  height: 0;
 }


### PR DESCRIPTION
with the new purgecss setup in the project (see https://github.com/carforyou/carforyou-listings-web/pull/1892) - global pseudo selectors seem to be purged. they work again when I combine them with an element selector