### PR TITLE
fix: do not add `type: button`  to div

### DIFF
--- a/src/components/__tests__/__snapshots__/button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/button.test.tsx.snap
@@ -110,7 +110,6 @@ exports[`<Button> button variations renders white Teal small button 1`] = `
 exports[`<Button> renders a div with link as a child 1`] = `
 <div
   class="flex w-12/12 justify-center items-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base rounded border focus:outline-none bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon"
-  type="button"
 >
   <a
     class="w-12/12 hover:opacity-100"

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -33,7 +33,7 @@ export const Button: FC<Props> = ({
   return (
     <div className="flex flex-col">
       {createElement(isWrapped ? "div" : "button", {
-        type: submit ? "submit" : "button",
+        ...(!isWrapped ? { type: submit ? "submit" : "button" } : {}),
         className: classnames(
           "flex w-12/12 justify-center items-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base rounded border focus:outline-none",
           { [padding]: !isWrapped },

--- a/src/components/segmentedControl/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/segmentedControl/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`<SegmentedControl> renders a div tag for a custom renderer with link 1`] = `
 <div
   class="flex w-12/12 justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-b-2 border-r-2 focus:outline-none bg-transparent text-teal border-teal focus:shadow-focus rounded-none hover:bg-teal-light active:bg-teal-bright"
-  type="button"
 >
   <a
     class="w-12/12 hover:opacity-100"

--- a/src/components/segmentedControl/button.tsx
+++ b/src/components/segmentedControl/button.tsx
@@ -24,7 +24,7 @@ export const Button: FC<Props> = ({
   const { clonedElement, isWrapped } = wrapLink(children, padding)
 
   return createElement(isWrapped ? "div" : "button", {
-    type: "button",
+    ...(!isWrapped ? { type: "button" } : {}),
     className: classnames(
       "flex w-12/12 justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-b-2 border-r-2 focus:outline-none",
       selected ? "bg-teal text-white" : "bg-transparent text-teal",


### PR DESCRIPTION
When fixing buttons in ie, we opted in for rendering a `div` instead of a `button` tag when an `a` tag is a child of the button.
What we did miss was that we still passed `type="button"` property to the resulting `div` which resulted in user agent styles not being properly cleared in Safari.