### PR TITLE
fix: modal options are optional

### DIFF
--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -20,7 +20,7 @@ const useModal = (
     style = "white",
     alwaysRender = false,
     container = null
-  } = options
+  } = options || {}
 
   const openModal = () => {
     setVisible(true)


### PR DESCRIPTION
I missed the fact that options passed to `useModal` are optional and did not provide a default value in 5.9.0. This fixes it.