### PR TITLE
fix: move babel-loader to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5407,15 +5407,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "@zeit/next-typescript": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@zeit/next-typescript/-/next-typescript-1.1.1.tgz",
-      "integrity": "sha512-EUcHCASftz1Bc80djkf3cKJrFgvFQyODOH1kty7ShVLLdXMaZpRLj+z7RxrCoNo1bP06w0vtXEDU0cKa0HmGgg==",
-      "dev": true,
-      "requires": {
-        "@babel/preset-typescript": "^7.0.0"
-      }
-    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@types/node": "^12.12.24",
     "@types/react": "^16.9.17",
     "@types/react-paginate": "^6.2.1",
-    "@zeit/next-typescript": "^1.1.1",
     "awesome-typescript-loader": "^5.2.1",
     "babel-loader": "^8.1.0",
     "jest": "^25.1.0",


### PR DESCRIPTION
unnecessarily forces a webpack peer dep upstream