### PR TITLE
fix: Revert "fix: change customValue color (#188)"

### DIFF
--- a/assets/input/select.css
+++ b/assets/input/select.css
@@ -1,4 +1,3 @@
-/* purgecss start ignore */
 .select {
   background-color: transparent;
   background-position: right;
@@ -29,12 +28,3 @@
 .select_withSearchIcon[data-valid="false"] {
   background-image: url("data:image/svg+xml,%3Csvg width='32' height='32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%23F73B47' d='M19.356 19.542l.05.05 4.535 4.535.353.354-.707.707-.353-.354L18.7 20.3l-.115-.115a7 7 0 1 1 .771-.643zM8.5 14.5a6 6 0 1 0 12 0 6 6 0 0 0-12 0z'/%3E%3C/svg%3E");
 }
- 
-.select_withQuotes::before {
-  content: '«'
-}
-
-.select_withQuotes::after {
-  content: '»'
-}
-/* purgecss end ignore */

--- a/src/components/dropdown/menu.tsx
+++ b/src/components/dropdown/menu.tsx
@@ -4,7 +4,7 @@ import Spinner from "../spinner"
 import { wrapLink } from "../../lib/buttonHelper"
 
 interface Item<T> {
-  value: T | { customValue: T }
+  value: T
   name: string
   key?: string
   placeholder?: boolean
@@ -33,31 +33,16 @@ interface Props<T> {
   isFetching?: boolean
 }
 
-const isCustomValue = (value): boolean => {
-  if (typeof value === "object") {
-    return "customValue" in value
-  }
-  return false
-}
-
 const hightlightItem = <T extends {}>({
   name,
   preMatch,
   match,
   postMatch,
-  value,
 }: Item<T>): ReactNode => {
   return match ? (
     <>
       {preMatch}
-      <span
-        className={classNames("font-bold underline", {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          select_withQuotes: isCustomValue(value),
-        })}
-      >
-        {match}
-      </span>
+      <span className="font-bold underline">{match}</span>
       {postMatch}
     </>
   ) : (
@@ -115,7 +100,7 @@ class Menu<T> extends Component<Props<T>> {
 
           const { clonedElement, isWrapped } = wrapLink(
             renderOption({
-              value: item.value as T,
+              value: item.value,
               name: hightlightItem(item),
               isSelected,
             }),
@@ -135,7 +120,6 @@ class Menu<T> extends Component<Props<T>> {
                     "font-bold text-teal": isSelected,
                     "bg-grey-bright": index === highlightedIndex,
                     "text-grey-3": item.placeholder,
-                    "text-teal": isCustomValue(item.value),
                     [padding]: !isWrapped,
                   }
                 ),

--- a/src/node.ts
+++ b/src/node.ts
@@ -9,7 +9,12 @@ export default {
     sync(resolve(__dirname, "../dist-src/components/**/*"), {
       nodir: true,
     }),
-  getWhitelistPatterns: () => [/^w-.*\/12$/],
+  getWhitelistPatterns: () => [
+    /^w-.*\/12$/,
+    /select_closed/,
+    /select_open/,
+    /select_withSearchIcon/,
+  ],
 }
 
 // Export all components


### PR DESCRIPTION
The change breaks the radius filters in the listings project.
If you go to https://localhost:3000/de/auto/search?cityId=2780&radius=20 and click on the `20 km` label the page will return a 500 error

![image](https://user-images.githubusercontent.com/3371760/83656761-3df52000-a5c0-11ea-865c-560928f6f038.png)

See: https://app.circleci.com/pipelines/github/carforyou/carforyou-listings-web/19162/workflows/013b62e3-3f19-4388-8fe0-71aad6e4eee2/jobs/160314/steps

This reverts commit 01540908fd680c6dad7b9c3b3b301f58bd63c23a.