### PR TITLE
fix: removes opacity corePlugins

### DIFF
--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -4,6 +4,8 @@ exports[`tailwind defaultConfig is accessible 1`] = `
 Object {
   "corePlugins": Object {
     "backgroundOpacity": false,
+    "borderOpacity": false,
+    "placeholderOpacity": false,
   },
   "plugins": Array [
     [Function],

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -624,7 +624,11 @@ export default {
     transitionTimingFunction: ["responsive", "hover"],
     transitionDuration: ["responsive", "hover"],
   },
-  corePlugins: { backgroundOpacity: false },
+  corePlugins: {
+    backgroundOpacity: false,
+    borderOpacity: false,
+    placeholderOpacity: false,
+  },
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   plugins: [TransformPlugin, require("tailwindcss-gradients")()],
 }


### PR DESCRIPTION
Previous fix didn't work because backgroundOpacity is a core plugin and i need to remove it in a different way.

https://tailwindcss.com/docs/configuration/#core-plugins

This way will make the bundle size stay the same and not include the 3 core plugins that we are not using at the moment. 