### PR TITLE
fix: remove getWhitelistPatterns

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -9,7 +9,6 @@ export default {
     sync(resolve(__dirname, "../dist-src/components/**/*"), {
       nodir: true,
     }),
-  getWhitelistPatterns: () => [/^w-.*\/12$/],
 }
 
 // Export all components


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/CAR-4013

BREAKING CHANGE: components-pkg no longer exposes `getWhitelistPatterns`. if your application contains any dynamic width classes, you will need to handle them in your app

the w-*/* whitelist was added because some applications use dynamic widths. in my opinion, purging CSS is an application concern. if we continue whitelisting classes globally, even they're not required in the applications, we unnecessarily bloat CSS bundles. I verified that components-pkg only contains purgeable css