### PR TITLE
fix: relative logo url with option to override

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -16,6 +16,7 @@ import useModal from "../../hooks/useModal"
 
 interface Props {
   theme?: HeaderTheme
+  logoUrl?: string
   mobileMenuText?: string
   links?: Array<JSX.Element>
   ctaButton?: JSX.Element
@@ -29,6 +30,7 @@ interface Props {
 
 const Header: FC<Props> = ({
   theme = HeaderTheme.LIGHT,
+  logoUrl = "/",
   links = [],
   ctaButton = null,
   iconButtons = [],
@@ -90,7 +92,7 @@ const Header: FC<Props> = ({
 
   const renderLogo = () => (
     <div className="min-w-100 w-logoSmall lg:w-logoDefault mr-20 xl:mr-40">
-      <a href="https://www.carforyou.ch/">{themeLog[theme]}</a>
+      <a href={logoUrl}>{themeLog[theme]}</a>
     </div>
   )
 

--- a/stories/header/header.stories.js
+++ b/stories/header/header.stories.js
@@ -501,6 +501,7 @@ storiesOf("Header", module)
         <div className="m-40 p-5" style={{ "background-color": "deeppink" }}>
           <Header
             theme={HeaderTheme.DARK}
+            logoUrl="https://www.carforyou.ch"
             links={dhLinks}
             ctaButton={dhCtaButton}
             profile={profile}


### PR DESCRIPTION
we hardcoded the logo url to https://www.carforyou.ch and in hindsight, I find that somewhat critical. I often find myself testing locally, clicking the logo and then not realizing I switched to production. I propose to default to `/`, while giving the private seller header in dealerhub the opportunity to override with `process.env.LISTINGS_URL` explicitly