### PR TITLE
feat: add pill component

### DIFF
--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -102,6 +102,7 @@ Object {
       "full": "9999px",
       "half": "50%",
       "none": "0",
+      "pill": "8px",
     },
     "borderWidth": Object {
       "0": "0",

--- a/src/components/pill.tsx
+++ b/src/components/pill.tsx
@@ -3,7 +3,7 @@ import classnames from "classnames"
 
 interface Props {
   children: ReactNode
-  secondary: boolean
+  secondary?: boolean
 }
 
 export const Pill: FC<Props> = ({ children, secondary }) => (

--- a/src/components/pill.tsx
+++ b/src/components/pill.tsx
@@ -1,0 +1,20 @@
+import React, { FC, ReactNode } from "react"
+import classnames from "classnames"
+
+interface Props {
+  children: ReactNode
+  secondary: boolean
+}
+
+export const Pill: FC<Props> = ({ children, secondary }) => (
+  <div
+    className={classnames(
+      "inline-block text-white rounded-pill text-xs pt-0 pb-1 px-5",
+      secondary ? "bg-black" : "bg-salmon"
+    )}
+  >
+    {children}
+  </div>
+)
+
+export default Pill

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Button from "./components/button"
+import Pill from "./components/pill"
 import Pagination from "./components/pagination"
 import Dropdown from "./components/dropdown/index"
 import DropdownWithAutosuggest from "./components/dropdown/withAutosuggest"
@@ -28,6 +29,7 @@ import Tooltip, {
 
 export {
   Button,
+  Pill,
   Pagination,
   Dropdown,
   DropdownWithAutosuggest,

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -134,6 +134,7 @@ export default {
       "4": "4px",
       "10": "10px",
       "20": "20px",
+      pill: "8px",
     },
 
     /*

--- a/stories/pill.stories.js
+++ b/stories/pill.stories.js
@@ -1,0 +1,26 @@
+import React from "react"
+import { storiesOf } from "@storybook/react"
+import { text, boolean } from "@storybook/addon-knobs"
+
+import { wInfo } from "./utils"
+import Pill from "../src/components/pill"
+
+storiesOf("Pill", module)
+  .add(
+    "Primary",
+    wInfo(`
+    Description
+    ~~~
+    <Pill>NEW</Pill>
+    ~~~
+    `)(() => <Pill secondary={boolean(false)}>{text("Label", "NEW")}</Pill>)
+  )
+  .add(
+    "Secondary",
+    wInfo(`
+    Description
+    ~~~
+    <Pill secondary>NEW</Pill>
+    ~~~
+    `)(() => <Pill secondary={boolean(true)}>{text("Label", "NEW")}</Pill>)
+  )


### PR DESCRIPTION
I will be using this in the header. the border-8 was not in the config and I want the header to use only tailwind values from components lib if possible

<img width="572" alt="Screenshot 2020-07-14 at 19 50 21" src="https://user-images.githubusercontent.com/2797/87459133-47d06100-c60b-11ea-8a22-5a4ead991a6d.png">
