### PR TITLE
fix: Modal onClose behaviour

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -23,11 +23,13 @@ interface Props {
 
 const Modal: FC<Props> = ({ close, onClose, size, style, children }) => {
   const handleClose = () => {
+    console.log("handleClose", onClose)
     onClose ? onClose() : null
     close()
   }
 
   const handleKeys = (e) => {
+    console.log("handleKeys called")
     if (e.keyCode === 27) {
       e.preventDefault()
       handleClose()

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -17,11 +17,15 @@ interface Props {
 }
 
 const Modal: FC<Props> = ({ close, onClose, size, style, children }) => {
+  const handleClose = () => {
+    onClose ? onClose() : null
+    close()
+  }
+
   const handleKeys = (e) => {
     if (e.keyCode === 27) {
       e.preventDefault()
-      onClose ? onClose() : null
-      close()
+      handleClose()
     }
   }
 
@@ -32,7 +36,7 @@ const Modal: FC<Props> = ({ close, onClose, size, style, children }) => {
 
   return (
     <div className="fixed inset-0 overflow-y-scroll scrolling-touch z-modal min-h-full transition duration-200 flex flex-col justify-center items-center md:overflow-y-auto">
-      <Overlay handleClick={close} />
+      <Overlay handleClick={handleClose} />
       <div
         className={classNames(
           "min-h-full max-h-full scrolling-touch md:overflow-y-auto overflow-y-scroll fixed inline-block md:relative",
@@ -45,10 +49,7 @@ const Modal: FC<Props> = ({ close, onClose, size, style, children }) => {
       >
         <div
           className="absolute z-modalClose cursor-pointer right-modalClose top-modalClose"
-          onClick={() => {
-            onClose ? onClose() : null
-            close()
-          }}
+          onClick={handleClose}
           data-testid="modal-close"
         >
           <CloseMIcon color={style === "dark" ? "#FFFFFF" : "#232A36"} />

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -9,10 +9,15 @@ export type ModalSize = "small" | "medium" | "large" | "fullscreen"
 export type ModalStyle = "white" | "dark"
 
 interface Props {
+  // Function to close the modal
   close: () => void
+  // Callback function called when the modal is closed
   onClose?: () => void
+  // Modal content
   children: (options: { closeModal: () => void }) => ReactNode
+  // Screen size
   size: ModalSize
+  // Background color
   style: ModalStyle
 }
 

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -23,13 +23,11 @@ interface Props {
 
 const Modal: FC<Props> = ({ close, onClose, size, style, children }) => {
   const handleClose = () => {
-    console.log("handleClose", onClose)
     onClose ? onClose() : null
     close()
   }
 
   const handleKeys = (e) => {
-    console.log("handleKeys called")
     if (e.keyCode === 27) {
       e.preventDefault()
       handleClose()

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -8,7 +8,7 @@ export type ModalSize = "small" | "medium" | "large" | "fullscreen"
 
 export type ModalStyle = "white" | "dark"
 
-interface Props {
+export interface ModalProps {
   // Function to close the modal
   close: () => void
   // Callback function called when the modal is closed
@@ -21,7 +21,7 @@ interface Props {
   style: ModalStyle
 }
 
-const Modal: FC<Props> = ({ close, onClose, size, style, children }) => {
+const Modal: FC<ModalProps> = ({ close, onClose, size, style, children }) => {
   const handleClose = () => {
     onClose ? onClose() : null
     close()

--- a/src/hooks/__tests__/useModal.test.tsx
+++ b/src/hooks/__tests__/useModal.test.tsx
@@ -69,46 +69,39 @@ describe("useModal", () => {
       fireEvent.keyDown(container, { keyCode: 27 })
 
       expect(container.firstChild).toMatchSnapshot()
+      expect(container).not.toContain(modalText)
     })
 
-    it.only("calls the onClose function when pressing ESC", async () => {
+    it("calls the onClose function when pressing ESC", async () => {
       const onCloseMock = jest.fn()
-      const { getByText, container } = renderWrapper(onCloseMock)
+      const { getByText, container, getByTestId } = renderWrapper(onCloseMock)
 
-      await act(async () => {
-        await fireEvent.click(getByText(buttonText))
-        getByText(modalText)
-        await fireEvent.keyDown(container, {
-          key: "ESC",
-          keyCode: 27,
-        })
+      fireEvent.click(getByText(buttonText))
+      getByText(modalText)
+      fireEvent.keyDown(container, {
+        keyCode: 27,
       })
 
       expect(onCloseMock).toBeCalledTimes(1)
     })
 
-    it.only("calls the onClose function the close button is clicked", async () => {
+    it("calls the onClose function the close button is clicked", async () => {
       const onCloseMock = jest.fn()
       const { getByText, getByTestId } = renderWrapper(onCloseMock)
 
-      await act(async () => {
-        await fireEvent.click(getByText(buttonText))
-        getByText(modalText)
-        await fireEvent.click(getByTestId("modal-close"))
-      })
+      fireEvent.click(getByText(buttonText))
+      getByText(modalText)
+      fireEvent.click(getByTestId("modal-close"))
 
       expect(onCloseMock).toBeCalledTimes(1)
     })
 
-    it.only("calls the onClose function when the overlay is clicked", async () => {
+    it("calls the onClose function when the overlay is clicked", async () => {
       const onCloseMock = jest.fn()
       const { getByText, getByTestId } = renderWrapper(onCloseMock)
-
-      await act(async () => {
-        await fireEvent.click(getByText(buttonText))
-        getByText(modalText)
-        await fireEvent.click(getByTestId("modal-overlay"))
-      })
+      fireEvent.click(getByText(buttonText))
+      getByText(modalText)
+      fireEvent.click(getByTestId("modal-overlay"))
 
       expect(onCloseMock).toBeCalledTimes(1)
     })

--- a/src/hooks/__tests__/useModal.test.tsx
+++ b/src/hooks/__tests__/useModal.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef, RefObject, FC } from "react"
-import { fireEvent, render, act } from "@testing-library/react"
+import { fireEvent, render } from "@testing-library/react"
 
 import useModal from "../useModal"
 
@@ -74,7 +74,7 @@ describe("useModal", () => {
 
     it("calls the onClose function when pressing ESC", async () => {
       const onCloseMock = jest.fn()
-      const { getByText, container, getByTestId } = renderWrapper(onCloseMock)
+      const { getByText, container } = renderWrapper(onCloseMock)
 
       fireEvent.click(getByText(buttonText))
       getByText(modalText)

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -5,15 +5,17 @@ import classNames from "classnames"
 
 import Modal, { ModalSize, ModalStyle } from "../components/modal/index"
 
+export interface UseModalOptions {
+  size?: ModalSize
+  style?: ModalStyle
+  alwaysRender?: boolean
+  container?: RefObject<HTMLDivElement>
+  onClose?: () => void
+}
+
 const useModal = (
   modal: (modalProps: { closeModal: () => void }) => JSX.Element,
-  options?: {
-    size?: ModalSize
-    style?: ModalStyle
-    alwaysRender?: boolean
-    container?: RefObject<HTMLDivElement>
-    onClose?: () => void
-  }
+  options?: UseModalOptions
 ) => {
   const [isVisible, setVisible] = useState(false)
   const {

--- a/stories/input/generator.tsx
+++ b/stories/input/generator.tsx
@@ -85,7 +85,7 @@ const generateStory = ({
   mode = "text",
 }) => {
   const onBlur = () => action("onBlur")
-  const onChange = () => action("onChange")
+  const onChange = () => action("w")
 
   const common = {
     name,

--- a/stories/input/generator.tsx
+++ b/stories/input/generator.tsx
@@ -85,7 +85,7 @@ const generateStory = ({
   mode = "text",
 }) => {
   const onBlur = () => action("onBlur")
-  const onChange = () => action("w")
+  const onChange = () => action("onChange")
 
   const common = {
     name,

--- a/stories/modal/generator.tsx
+++ b/stories/modal/generator.tsx
@@ -1,10 +1,11 @@
-import React from "react"
+import React, { FC } from "react"
 import classNames from "classnames"
 
 import { wInfo } from "../utils"
 
-import useModal from "../../src/hooks/useModal"
+import useModal, { UseModalOptions } from "../../src/hooks/useModal"
 import Button from "../../src/components/button"
+import { action } from "@storybook/addon-actions"
 
 const generateDescription = ({
   size,
@@ -39,12 +40,12 @@ ${onClose ? `      onClose: ${onClose}` : ""}
 }
 
 const generateStoryFunction = ({
-  size,
   alwaysRender,
   container,
+  size,
   style,
   onClose,
-}) => () => {
+}) => {
   function ModalDemo() {
     const { openModal, renderModal } = useModal(
       () => (
@@ -82,7 +83,7 @@ const generateStoryFunction = ({
     )
   }
 
-  return (
+  return () => (
     <div className="mx-30 mb-40">
       <div className="text-2xl mb-20">Example</div>
       <div className="w-12/12 md:w-3/12">
@@ -97,11 +98,27 @@ const generateModalStory = ({
   alwaysRender = false,
   container = null,
   style = "white",
-  onClose = null,
+  onCloseActionText = null,
 }) => {
+  const onClose = onCloseActionText ? action(onCloseActionText) : null
+
   return wInfo(
-    generateDescription({ size, alwaysRender, container, style, onClose })
-  )(generateStoryFunction({ size, alwaysRender, container, style, onClose }))
+    generateDescription({
+      size,
+      alwaysRender,
+      container,
+      style,
+      onClose,
+    })
+  )(
+    generateStoryFunction({
+      size,
+      alwaysRender,
+      container,
+      style,
+      onClose,
+    })
+  )
 }
 
 export default generateModalStory

--- a/stories/modal/generator.tsx
+++ b/stories/modal/generator.tsx
@@ -1,9 +1,9 @@
-import React, { FC } from "react"
+import React from "react"
 import classNames from "classnames"
 
 import { wInfo } from "../utils"
 
-import useModal, { UseModalOptions } from "../../src/hooks/useModal"
+import useModal from "../../src/hooks/useModal"
 import Button from "../../src/components/button"
 import { action } from "@storybook/addon-actions"
 

--- a/stories/modal/generator.tsx
+++ b/stories/modal/generator.tsx
@@ -6,7 +6,13 @@ import { wInfo } from "../utils"
 import useModal from "../../src/hooks/useModal"
 import Button from "../../src/components/button"
 
-const generateDescription = ({ size, alwaysRender, container, style }) => {
+const generateDescription = ({
+  size,
+  alwaysRender,
+  container,
+  style,
+  onClose,
+}) => {
   return `
   Description
   ~~~
@@ -18,6 +24,7 @@ ${size ? `      size: ${size},` : ""}
 ${alwaysRender ? `      alwaysRender: ${alwaysRender},` : ""}
 ${container ? `      container: ${container},` : ""}
 ${style ? `      style: ${style}` : ""}
+${onClose ? `      onClose: ${onClose}` : ""}
     })
 
     return (
@@ -36,6 +43,7 @@ const generateStoryFunction = ({
   alwaysRender,
   container,
   style,
+  onClose,
 }) => () => {
   function ModalDemo() {
     const { openModal, renderModal } = useModal(
@@ -63,7 +71,7 @@ const generateStoryFunction = ({
           </p>
         </div>
       ),
-      { size, alwaysRender, container, style }
+      { size, alwaysRender, container, style, onClose }
     )
 
     return (
@@ -84,15 +92,16 @@ const generateStoryFunction = ({
   )
 }
 
-const generareStrory = ({
+const generateModalStory = ({
   size = "medium",
   alwaysRender = false,
   container = null,
   style = "white",
+  onClose = null,
 }) => {
-  return wInfo(generateDescription({ size, alwaysRender, container, style }))(
-    generateStoryFunction({ size, alwaysRender, container, style })
-  )
+  return wInfo(
+    generateDescription({ size, alwaysRender, container, style, onClose })
+  )(generateStoryFunction({ size, alwaysRender, container, style, onClose }))
 }
 
-export default generareStrory
+export default generateModalStory

--- a/stories/modal/index.stories.tsx
+++ b/stories/modal/index.stories.tsx
@@ -8,9 +8,7 @@ storiesOf("Modal", module)
     "Small with onClose event",
     generateModalStory({
       size: "small",
-      onClose: () => {
-        alert("onClose callback called")
-      },
+      onCloseActionText: "onClose callback called",
     })
   )
   .add("Medium", generateModalStory({ size: "medium" }))

--- a/stories/modal/index.stories.tsx
+++ b/stories/modal/index.stories.tsx
@@ -1,10 +1,22 @@
 import { storiesOf } from "@storybook/react"
 
-import generateStory from "./generator"
+import generateModalStory from "./generator"
 
 storiesOf("Modal", module)
-  .add("Small", generateStory({ size: "small" }))
-  .add("Medium", generateStory({ size: "medium" }))
-  .add("Large", generateStory({ size: "large" }))
-  .add("Fulscreen", generateStory({ size: "fullscreen" }))
-  .add("Dark Fulscreen", generateStory({ style: "dark", size: "fullscreen" }))
+  .add("Small", generateModalStory({ size: "small" }))
+  .add(
+    "Small with onClose event",
+    generateModalStory({
+      size: "small",
+      onClose: () => {
+        alert("onClose callback called")
+      },
+    })
+  )
+  .add("Medium", generateModalStory({ size: "medium" }))
+  .add("Large", generateModalStory({ size: "large" }))
+  .add("Fulscreen", generateModalStory({ size: "fullscreen" }))
+  .add(
+    "Dark Fulscreen",
+    generateModalStory({ style: "dark", size: "fullscreen" })
+  )


### PR DESCRIPTION
- fix: calls the onClose event when the user clicks on the overlay
- tests: unit tests for all onClose cases
- story book: adds example for the onClose event

<img width="1920" alt="Screenshot 2020-07-22 at 14 17 30" src="https://user-images.githubusercontent.com/3371760/88181263-e45bba00-cc2e-11ea-8fe3-49e65a58ebde.png">
