### PR TITLE
fix: do not hardcode tooltip width

### DIFF
--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -390,7 +390,6 @@ Object {
       "radioIndicator": "12px",
       "screen": "100vw",
       "scrollbar": "14px",
-      "tooltip": "320px",
     },
     "zIndex": Object {
       "auto": "auto",

--- a/src/components/tooltip/popUp.tsx
+++ b/src/components/tooltip/popUp.tsx
@@ -12,7 +12,7 @@ interface Props {
 const PopUp: FC<Props> = ({ children, position, alignment }) => (
   <div
     className={classNames(
-      "w-tooltip p-15 bg-white rounded-4 shadow-hard z-modal absolute transform",
+      "p-15 bg-white rounded-4 shadow-hard z-modal absolute transform",
       {
         "bottom-tooltip mb-10": position === TooltipPosition.top,
         "top-tooltip mt-10": position === TooltipPosition.bottom,

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -505,7 +505,6 @@ export default {
       logoDefault: "170px",
       logoSmall: "140px",
       profileDropdown: "320px",
-      tooltip: "320px",
     },
 
     transitionDuration: {

--- a/stories/tooltip/generator.tsx
+++ b/stories/tooltip/generator.tsx
@@ -9,7 +9,7 @@ const generateDescription = ({ position, alignment }) => {
   Description
   ~~~
   <Tooltip
-    renderContent={() => <div>Tooltip content.</div>}
+    renderContent={() => <div className="w-...">Tooltip content.</div>}
     getPosition={() => "${position}"}
     alignment="${alignment}"
   >
@@ -26,7 +26,7 @@ const generateStoryFunction = ({ position, alignment }) => () => {
       <div className="w-12/12 flex justify-center">
         <Tooltip
           renderContent={() => (
-            <p>
+            <p className="w-modalSmall">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit.
               Vestibulum urna augue, consectetur at sapien eu, facilisis
               gravida.


### PR DESCRIPTION
When we added the `Tooltip` component we assumed that the width will always be fixed. That's not the case - different designs show different tooltip widths.

This removes the hardcoded width class and moves the width setting to the content.
