### PR TITLE
fix: ensure tooltip always has rouded corners

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -5,3 +5,4 @@
 @import "./spinner.css";
 @import "./intercom.css";
 @import "./header.css";
+@import "./tooltip.css";

--- a/assets/tooltip.css
+++ b/assets/tooltip.css
@@ -1,0 +1,5 @@
+/* purgecss start ignore */
+.react-tooltip-lite-arrow {
+  @apply border-white;
+}
+/* purgecss end ignore */

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -47,11 +47,12 @@ const Tooltip: FC<Props> = ({
     <div className="inline-block" onClick={(e) => e.preventDefault()}>
       <TooltipTrigger
         content={
-          <div className="p-15 shadow-hard rounded-4">{renderContent()}</div>
+          <div className="rounded-4 shadow-hard p-15 bg-white">
+            {renderContent()}
+          </div>
         }
         direction={`${preferredPosition}-${alignment}`}
         padding="0px"
-        background="#fff"
         tipContentHover={true}
       >
         {children}


### PR DESCRIPTION
It turns out that just using background colours of the tooltip can break border-radius in a rare case when the tooltip is displayed over images/elements with overflows.

**before**
<img width="598" alt="Screenshot 2020-07-30 15 14 43" src="https://user-images.githubusercontent.com/144707/88927648-03ce9480-d278-11ea-9937-fc03d289c759.png">

**after**
<img width="627" alt="Screenshot 2020-07-30 15 13 00" src="https://user-images.githubusercontent.com/144707/88927605-f0232e00-d277-11ea-8337-b03e935786da.png">

Unfortunately, there's no way around custom CSS here, but I believe we can live with one simple class.