### PR TITLE
feat: add container max-width

### DIFF
--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -273,6 +273,7 @@ Object {
       "full": "100%",
     },
     "maxWidth": Object {
+      "container": "1200px",
       "full": "100%",
     },
     "minHeight": Object {

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -359,6 +359,7 @@ export default {
     */
     maxWidth: {
       full: "100%",
+      container: "1200px",
     },
 
     /*


### PR DESCRIPTION
We define the same `container` max-width in all the projects. We want to use the same value in the footer too.