### PR TITLE
feat: change intercom button colour

### DIFF
--- a/src/components/intercom/index.tsx
+++ b/src/components/intercom/index.tsx
@@ -132,7 +132,7 @@ export const Intercom: FC<Props> = ({
         className={classNames(
           styles.launcher,
           "sticky fixed text-white py-2 cursor-pointer transition-3 hover:opacity-60",
-          state === State.Open ? "bg-teal" : "bg-grey-4"
+          state === State.Open ? "bg-teal" : "bg-grey-dark"
         )}
         id={intercomLauncherId}
         onClick={() => {


### PR DESCRIPTION
The current colour of intercom conflicts with the colour used for dealer promotion. This results in really shitty view on mobile where the button blends in with the promotion. After checking with Enrique we decided to switch to a darker shade of grey. 

**before**
<img width="215" alt="Screenshot 2020-09-02 at 11 49 33" src="https://user-images.githubusercontent.com/144707/91978914-38c18180-ed25-11ea-9dd9-ae6b772ec526.png">

**after**
<img width="181" alt="Screenshot 2020-09-02 at 14 02 33" src="https://user-images.githubusercontent.com/144707/91978792-06b01f80-ed25-11ea-81e4-b55c4c4d6822.png">
