### PR TITLE
fix: whitelist scrolling classes

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -37,6 +37,7 @@ h4 {
   @apply opacity-100;
 }
 
+/* purgecss ignore */
 .preventScrolling {
   @apply fixed overflow-hidden;
 }
@@ -51,6 +52,7 @@ h4 {
 }
 
 @screen lg {
+  /* purgecss ignore */
   .preventScrolling {
     @apply relative;
   }


### PR DESCRIPTION
Fixes CAR-5561

The `preventScrolling` classes are dynamic and therefore stripped by purgeCSS.
