### PR TITLE
fix: fullscreen modal

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -44,10 +44,10 @@ const Modal: FC<ModalProps> = ({ close, onClose, size, style, children }) => {
       <Overlay handleClick={handleClose} />
       <div
         className={classNames(
-          "min-h-full max-h-full scrolling-touch md:overflow-y-auto overflow-y-scroll fixed inline-block md:relative",
+          "min-h-full max-h-full scrolling-touch md:overflow-y-auto overflow-y-scroll fixed inline-block",
           size === "fullscreen"
             ? "inset-0"
-            : "inset-x-0 md:min-h-auto md:align-middle md:inset-auto h-full md:h-auto rounded-4",
+            : "inset-x-0 md:min-h-auto md:align-middle md:inset-auto md:relative h-full md:h-auto rounded-4",
           style === "white" ? "bg-white" : "bg-grey-dark text-white"
         )}
         role="dialog"

--- a/src/hooks/__tests__/__snapshots__/useModal.test.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/useModal.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`useModal with a portal renders the modal within the portal 1`] = `
       data-testid="modal-overlay"
     />
     <div
-      class="min-h-full max-h-full scrolling-touch md:overflow-y-auto overflow-y-scroll fixed inline-block md:relative inset-x-0 md:min-h-auto md:align-middle md:inset-auto h-full md:h-auto rounded-4 bg-white"
+      class="min-h-full max-h-full scrolling-touch md:overflow-y-auto overflow-y-scroll fixed inline-block inset-x-0 md:min-h-auto md:align-middle md:inset-auto md:relative h-full md:h-auto rounded-4 bg-white"
       role="dialog"
     >
       <div
@@ -87,7 +87,7 @@ exports[`useModal without portal renders the modal within the container 1`] = `
         data-testid="modal-overlay"
       />
       <div
-        class="min-h-full max-h-full scrolling-touch md:overflow-y-auto overflow-y-scroll fixed inline-block md:relative inset-x-0 md:min-h-auto md:align-middle md:inset-auto h-full md:h-auto rounded-4 bg-white"
+        class="min-h-full max-h-full scrolling-touch md:overflow-y-auto overflow-y-scroll fixed inline-block inset-x-0 md:min-h-auto md:align-middle md:inset-auto md:relative h-full md:h-auto rounded-4 bg-white"
         role="dialog"
       >
         <div


### PR DESCRIPTION
Stumbled upon an issue with the fullscreen modal, where it overrides `fixed` on medium viewport:

*Before*
<img width="896" alt="Screenshot 2020-12-10 at 14 35 48" src="https://user-images.githubusercontent.com/144707/101779198-370e1380-3af5-11eb-839b-4c25c59dbebf.png">

*After*
<img width="896" alt="Screenshot 2020-12-10 at 14 35 53" src="https://user-images.githubusercontent.com/144707/101779262-5442e200-3af5-11eb-8778-3518764ef2a6.png">
