### PR TITLE
CFYEO-39: Remove classname props

### DIFF
--- a/assets/input/basic.css
+++ b/assets/input/basic.css
@@ -88,22 +88,12 @@ textarea[data-valid="false"]:focus {
 }
 
 input.input_left {
-  @apply rounded-l-4 rounded-r-none;
+  @apply rounded-r-none;
 }
 
 input.input_right,
 div.input_right {
-  @apply rounded-r-4 rounded-l-none -ml-1;
-}
-
-.input_left:hover,
-.input_right:hover {
-  @apply z-1 transition duration-200;
-}
-
-.input_left:focus,
-.input_right:focus {
-  @apply z-1;
+  @apply rounded-l-none;
 }
 
 /* hide ie specific input controls */

--- a/assets/input/basic.css
+++ b/assets/input/basic.css
@@ -51,7 +51,6 @@ textarea:focus {
   @apply border-teal outline-none;
 }
 
-
 input[type="number"]:hover,
 input[type="text"]:hover,
 input[type="checkbox"]:hover:not(.checkbox-buttonStyle),
@@ -86,6 +85,25 @@ input[type="number"][data-valid="false"]:focus,
 input[type="text"][data-valid="false"]:focus,
 textarea[data-valid="false"]:focus {
   @apply text-grey-dark;
+}
+
+input.input_left {
+  @apply rounded-l-4 rounded-r-none;
+}
+
+input.input_right,
+div.input_right {
+  @apply rounded-r-4 rounded-l-none -ml-1;
+}
+
+.input_left:hover,
+.input_right:hover {
+  @apply z-1 transition duration-200;
+}
+
+.input_left:focus,
+.input_right:focus {
+  @apply z-1;
 }
 
 /* hide ie specific input controls */

--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -661,6 +661,8 @@ Object {
     ],
     "zIndex": Array [
       "responsive",
+      "hover",
+      "focus",
     ],
   },
 }

--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -252,6 +252,7 @@ Object {
       },
     },
     "margin": Object {
+      "-1": "-1px",
       "-headerMenu": "-14px",
       "-headerMenuMore": "-28px",
       "-selectMenu": "-21px",
@@ -400,6 +401,7 @@ Object {
       "scrollbar": "14px",
     },
     "zIndex": Object {
+      "1": 1,
       "auto": "auto",
       "card": 10,
       "clearButton": 10,

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -89,10 +89,7 @@ function Dropdown<T>({
       menu={(downshift, filteredOptions) => {
         const props = {
           ...downshift,
-          ...downshift.getMenuProps({
-            //className: "text-left md:position-left-auto shadow-hard md:shadow-soft rounded-none md:rounded-4",
-            //className: "shadow-soft rounded-4",
-          }),
+          ...downshift.getMenuProps({}),
           options: [
             ...(placeholder
               ? [{ name: placeholder, value: null, placeholder: true }]

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -51,6 +51,7 @@ interface Props<T> {
    */
   equal?: (a: T, b: T) => boolean
   hasHint?: boolean
+  isSelect?: boolean
 }
 
 function Dropdown<T>({
@@ -63,6 +64,7 @@ function Dropdown<T>({
   disabled,
   renderOption,
   hasHint,
+  isSelect = false,
 }: Props<T>): ReactElement {
   return (
     <BaseDownshift
@@ -89,7 +91,13 @@ function Dropdown<T>({
       menu={(downshift, filteredOptions) => {
         const props = {
           ...downshift,
-          ...downshift.getMenuProps({}),
+          ...downshift.getMenuProps({
+            className: isSelect
+              ? hasHint
+                ? "-mt-selectWithHintMenu"
+                : "-mt-selectMenu"
+              : "",
+          }),
           options: [
             ...(placeholder
               ? [{ name: placeholder, value: null, placeholder: true }]
@@ -97,7 +105,6 @@ function Dropdown<T>({
             ...filteredOptions,
           ],
           renderOption,
-          hasHint,
         }
 
         return <Menu {...props} />

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -50,8 +50,7 @@ interface Props<T> {
    *  Defaults to ===
    */
   equal?: (a: T, b: T) => boolean
-  hasHint?: boolean
-  isSelect?: boolean
+  menuClassName?: string
 }
 
 function Dropdown<T>({
@@ -63,8 +62,7 @@ function Dropdown<T>({
   toggle,
   disabled,
   renderOption,
-  hasHint,
-  isSelect = false,
+  menuClassName,
 }: Props<T>): ReactElement {
   return (
     <BaseDownshift
@@ -92,11 +90,7 @@ function Dropdown<T>({
         const props = {
           ...downshift,
           ...downshift.getMenuProps({
-            className: isSelect
-              ? hasHint
-                ? "-mt-selectWithHintMenu"
-                : "-mt-selectMenu"
-              : "",
+            className: menuClassName,
           }),
           options: [
             ...(placeholder

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -50,7 +50,7 @@ interface Props<T> {
    *  Defaults to ===
    */
   equal?: (a: T, b: T) => boolean
-  menuClassName?: string
+  hasHint?: boolean
 }
 
 function Dropdown<T>({
@@ -62,7 +62,7 @@ function Dropdown<T>({
   toggle,
   disabled,
   renderOption,
-  menuClassName,
+  hasHint,
 }: Props<T>): ReactElement {
   return (
     <BaseDownshift
@@ -90,10 +90,8 @@ function Dropdown<T>({
         const props = {
           ...downshift,
           ...downshift.getMenuProps({
-            className: classNames(
-              "text-left rounded-none shadow-hard md:position-left-auto md:shadow-soft md:rounded-4",
-              menuClassName
-            ),
+            //className: "text-left md:position-left-auto shadow-hard md:shadow-soft rounded-none md:rounded-4",
+            //className: "shadow-soft rounded-4",
           }),
           options: [
             ...(placeholder
@@ -102,6 +100,7 @@ function Dropdown<T>({
             ...filteredOptions,
           ],
           renderOption,
+          hasHint,
         }
 
         return <Menu {...props} />

--- a/src/components/dropdown/menu.tsx
+++ b/src/components/dropdown/menu.tsx
@@ -87,7 +87,7 @@ class Menu<T> extends Component<Props<T>> {
       noResults,
       inputValue,
       isFetching,
-      hasHint,
+      //hasHint,
     } = this.props
 
     let { renderOption } = this.props
@@ -101,8 +101,8 @@ class Menu<T> extends Component<Props<T>> {
         {...getMenuProps(
           {
             className: classNames(
-              "border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 list-reset scrolling-touch overflow-y-scroll custom-scrollbar max-h-dropdownSM md:max-h-dropdown py-10 shadow-soft rounded-4",
-              { "-mt-selectWithHintMenu": hasHint, "-mt-selectMenu": !hasHint }
+              "border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 list-reset scrolling-touch overflow-y-scroll custom-scrollbar max-h-dropdownSM md:max-h-dropdown py-10 shadow-soft rounded-4"
+              //{ "-mt-selectWithHintMenu": hasHint, "-mt-selectMenu": !hasHint }
             ),
 
             onMouseLeave: () => {
@@ -154,8 +154,8 @@ class Menu<T> extends Component<Props<T>> {
     ) : inputValue && noResults ? (
       <div
         className={classNames(
-          "p-20 text-grey-3 border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 shadow-soft rounded-4",
-          { "-mt-selectWithHintMenu": hasHint, "-mt-selectMenu": !hasHint }
+          "p-20 text-grey-3 border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 shadow-soft rounded-4"
+          //{ "-mt-selectWithHintMenu": hasHint, "-mt-selectMenu": !hasHint }
         )}
       >
         {isFetching ? (

--- a/src/components/dropdown/menu.tsx
+++ b/src/components/dropdown/menu.tsx
@@ -25,6 +25,7 @@ interface Props<T> {
   selectedItem?: Item<T>
   inputValue?: string
   options: Array<Item<T>>
+  className?: string
   equal?: (a: T, b: T) => boolean
   innerRef?: Ref<HTMLUListElement>
   renderOption?: (option: {
@@ -34,7 +35,6 @@ interface Props<T> {
   }) => ReactNode
   noResults?: string
   isFetching?: boolean
-  hasHint: boolean
 }
 
 const isCustomValue = (value): boolean => {
@@ -83,11 +83,11 @@ class Menu<T> extends Component<Props<T>> {
       highlightedIndex,
       selectedItem,
       options,
+      className,
       innerRef,
       noResults,
       inputValue,
       isFetching,
-      //hasHint,
     } = this.props
 
     let { renderOption } = this.props
@@ -101,10 +101,9 @@ class Menu<T> extends Component<Props<T>> {
         {...getMenuProps(
           {
             className: classNames(
-              "border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 list-reset scrolling-touch overflow-y-scroll custom-scrollbar max-h-dropdownSM md:max-h-dropdown py-10 shadow-soft rounded-4"
-              //{ "-mt-selectWithHintMenu": hasHint, "-mt-selectMenu": !hasHint }
+              "border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 list-reset scrolling-touch overflow-y-scroll custom-scrollbar max-h-dropdownSM md:max-h-dropdown py-10 shadow-soft rounded-4",
+              className
             ),
-
             onMouseLeave: () => {
               setHighlightedIndex(null)
             },
@@ -154,8 +153,8 @@ class Menu<T> extends Component<Props<T>> {
     ) : inputValue && noResults ? (
       <div
         className={classNames(
-          "p-20 text-grey-3 border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 shadow-soft rounded-4"
-          //{ "-mt-selectWithHintMenu": hasHint, "-mt-selectMenu": !hasHint }
+          "p-20 text-grey-3 border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 shadow-soft rounded-4",
+          className
         )}
       >
         {isFetching ? (

--- a/src/components/dropdown/menu.tsx
+++ b/src/components/dropdown/menu.tsx
@@ -25,7 +25,6 @@ interface Props<T> {
   selectedItem?: Item<T>
   inputValue?: string
   options: Array<Item<T>>
-  className?: string
   equal?: (a: T, b: T) => boolean
   innerRef?: Ref<HTMLUListElement>
   renderOption?: (option: {
@@ -35,6 +34,7 @@ interface Props<T> {
   }) => ReactNode
   noResults?: string
   isFetching?: boolean
+  hasHint: boolean
 }
 
 const isCustomValue = (value): boolean => {
@@ -83,11 +83,11 @@ class Menu<T> extends Component<Props<T>> {
       highlightedIndex,
       selectedItem,
       options,
-      className,
       innerRef,
       noResults,
       inputValue,
       isFetching,
+      hasHint,
     } = this.props
 
     let { renderOption } = this.props
@@ -101,9 +101,10 @@ class Menu<T> extends Component<Props<T>> {
         {...getMenuProps(
           {
             className: classNames(
-              "border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 list-reset scrolling-touch overflow-y-scroll custom-scrollbar max-h-dropdownSM md:max-h-dropdown py-10",
-              className
+              "border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 list-reset scrolling-touch overflow-y-scroll custom-scrollbar max-h-dropdownSM md:max-h-dropdown py-10 shadow-soft rounded-4",
+              { "-mt-selectWithHintMenu": hasHint, "-mt-selectMenu": !hasHint }
             ),
+
             onMouseLeave: () => {
               setHighlightedIndex(null)
             },
@@ -153,8 +154,8 @@ class Menu<T> extends Component<Props<T>> {
     ) : inputValue && noResults ? (
       <div
         className={classNames(
-          "p-20 text-grey-3 border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0",
-          className
+          "p-20 text-grey-3 border border-grey-2 absolute z-dropdownMenu bg-white cursor-normal inset-x-0 shadow-soft rounded-4",
+          { "-mt-selectWithHintMenu": hasHint, "-mt-selectMenu": !hasHint }
         )}
       >
         {isFetching ? (

--- a/src/components/dropdown/withAutosuggest.tsx
+++ b/src/components/dropdown/withAutosuggest.tsx
@@ -269,19 +269,26 @@ function DropdownWithAutosuggest<T>({
       toggle={renderToggle}
       menu={(downshift, filteredOptions) => {
         return (
-          <Menu<T>
-            {...{
-              ...downshift,
-              innerRef: menuRef,
-              options: filteredOptions,
-              //className: "shadow-soft rounded-4",
-              equal: equalWrapper,
-              noResults,
-              hasHint,
-              inputValue,
-              isFetching,
-            }}
-          />
+          <div
+            className={classNames("", {
+              "-mt-selectWithHintMenu": hasHint,
+              "-mt-selectMenu": !hasHint,
+            })}
+          >
+            <Menu<T>
+              {...{
+                ...downshift,
+                innerRef: menuRef,
+                options: filteredOptions,
+                //className: "shadow-soft rounded-4",
+                equal: equalWrapper,
+                noResults,
+                hasHint,
+                inputValue,
+                isFetching,
+              }}
+            />
+          </div>
         )
       }}
     />

--- a/src/components/dropdown/withAutosuggest.tsx
+++ b/src/components/dropdown/withAutosuggest.tsx
@@ -63,8 +63,8 @@ interface Props<T> {
   fetchSuggestions?: (
     value: string
   ) => Promise<Array<{ value: T; name: string }>>
-  menuClassName?: string
   noResults?: string
+  hasHint?: boolean
 }
 
 const filterOptions = (noResults) => (allOptions, text) => {
@@ -121,8 +121,8 @@ function DropdownWithAutosuggest<T>({
   fetchSuggestions,
   trimInput,
   allowCustomValues = false,
-  menuClassName,
   noResults,
+  hasHint,
 }: Props<T>): ReactElement {
   const menuRef: Ref<HTMLUListElement> = useRef()
   const [inputValue, setInputValue] = useState("")
@@ -274,9 +274,10 @@ function DropdownWithAutosuggest<T>({
               ...downshift,
               innerRef: menuRef,
               options: filteredOptions,
-              className: classNames("shadow-soft rounded-4", menuClassName),
+              //className: "shadow-soft rounded-4",
               equal: equalWrapper,
               noResults,
+              hasHint,
               inputValue,
               isFetching,
             }}

--- a/src/components/dropdown/withAutosuggest.tsx
+++ b/src/components/dropdown/withAutosuggest.tsx
@@ -269,26 +269,18 @@ function DropdownWithAutosuggest<T>({
       toggle={renderToggle}
       menu={(downshift, filteredOptions) => {
         return (
-          <div
-            className={classNames("", {
-              "-mt-selectWithHintMenu": hasHint,
-              "-mt-selectMenu": !hasHint,
-            })}
-          >
-            <Menu<T>
-              {...{
-                ...downshift,
-                innerRef: menuRef,
-                options: filteredOptions,
-                //className: "shadow-soft rounded-4",
-                equal: equalWrapper,
-                noResults,
-                hasHint,
-                inputValue,
-                isFetching,
-              }}
-            />
-          </div>
+          <Menu<T>
+            {...{
+              ...downshift,
+              innerRef: menuRef,
+              options: filteredOptions,
+              className: hasHint ? "-mt-selectWithHintMenu" : "-mt-selectMenu",
+              equal: equalWrapper,
+              noResults,
+              inputValue,
+              isFetching,
+            }}
+          />
         )
       }}
     />

--- a/src/components/dropdown/withAutosuggest.tsx
+++ b/src/components/dropdown/withAutosuggest.tsx
@@ -272,9 +272,13 @@ function DropdownWithAutosuggest<T>({
           <Menu<T>
             {...{
               ...downshift,
+              ...downshift.getMenuProps({
+                className: hasHint
+                  ? "-mt-selectWithHintMenu"
+                  : "-mt-selectMenu",
+              }),
               innerRef: menuRef,
               options: filteredOptions,
-              className: hasHint ? "-mt-selectWithHintMenu" : "-mt-selectMenu",
               equal: equalWrapper,
               noResults,
               inputValue,

--- a/src/components/dropdown/withAutosuggest.tsx
+++ b/src/components/dropdown/withAutosuggest.tsx
@@ -63,8 +63,8 @@ interface Props<T> {
   fetchSuggestions?: (
     value: string
   ) => Promise<Array<{ value: T; name: string }>>
+  menuClassName?: string
   noResults?: string
-  hasHint?: boolean
 }
 
 const filterOptions = (noResults) => (allOptions, text) => {
@@ -121,8 +121,8 @@ function DropdownWithAutosuggest<T>({
   fetchSuggestions,
   trimInput,
   allowCustomValues = false,
+  menuClassName,
   noResults,
-  hasHint,
 }: Props<T>): ReactElement {
   const menuRef: Ref<HTMLUListElement> = useRef()
   const [inputValue, setInputValue] = useState("")
@@ -272,13 +272,9 @@ function DropdownWithAutosuggest<T>({
           <Menu<T>
             {...{
               ...downshift,
-              ...downshift.getMenuProps({
-                className: hasHint
-                  ? "-mt-selectWithHintMenu"
-                  : "-mt-selectMenu",
-              }),
               innerRef: menuRef,
               options: filteredOptions,
+              className: menuClassName,
               equal: equalWrapper,
               noResults,
               inputValue,

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -100,8 +100,10 @@ const Input = forwardRef<HTMLInputElement, Props>(
           // eslint-disable-next-line @typescript-eslint/naming-convention
           "select_withSearchIcon bg-right bg-transparent bg-no-repeat": hasSearchIcon,
           "floatingLabel-input": labelProps.floating,
-          input_left: position === "left",
-          input_right: position === "right",
+          "input_left hover:z-1 hover:transition hover:duration-200 focus:z-1":
+            position === "left",
+          "input_right -ml-1 hover:z-1 hover:transition hover:duration-200 focus:z-1":
+            position === "right",
         })}
         mode={mode}
         hasError={hasError}

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -27,7 +27,7 @@ interface InputProps {
   step?: number
   min?: number
   max?: number
-  className?: string
+  position?: "left" | "right"
   debounce?: number
 }
 
@@ -64,7 +64,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
       step,
       min,
       max,
-      className,
+      position,
       debounce,
       ...rest
     },
@@ -92,10 +92,12 @@ const Input = forwardRef<HTMLInputElement, Props>(
         name={name}
         value={value || ""}
         placeholder={placeholder || ""}
-        className={classNames("w-12/12", className, {
+        className={classNames("w-12/12", {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           input_withClearButton: hasClearButton,
           "floatingLabel-input": labelProps.floating,
+          input_left: position === "left",
+          input_right: position === "right",
         })}
         mode={mode}
         hasError={hasError}

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -17,6 +17,7 @@ interface InputProps {
   disabled?: boolean
   autoFocus?: boolean
   hasClearButton?: boolean
+  hasSearchIcon?: boolean
   mode: "text" | "numeric" | "decimal" | "tel" | "email"
   onChange: <T extends { target: { name: string; value: string | number } }>(
     e: T
@@ -55,6 +56,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
       hint,
       disabled = false,
       hasClearButton = false,
+      hasSearchIcon = false,
       autoFocus = false,
       mode,
       onChange,
@@ -95,6 +97,8 @@ const Input = forwardRef<HTMLInputElement, Props>(
         className={classNames("w-12/12", {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           input_withClearButton: hasClearButton,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          "select_withSearchIcon bg-right bg-transparent bg-no-repeat": hasSearchIcon,
           "floatingLabel-input": labelProps.floating,
           input_left: position === "left",
           input_right: position === "right",

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -71,7 +71,10 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
       options,
       onSelect: handleChange,
       selected,
-      hasHint: hint ? true : false,
+      hasHint:
+        hint && "withAutosuggest" in rest && rest.withAutosuggest
+          ? true
+          : false,
       //menuClassName: hint ? "-mt-selectWithHintMenu" : "-mt-selectMenu",
     }
 

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -71,7 +71,7 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
       options,
       onSelect: handleChange,
       selected,
-      hasHint: hint ? true : false,
+      menuClassName: hint ? "-mt-selectWithHintMenu" : "-mt-selectMenu",
     }
 
     const dropdownProps =
@@ -127,7 +127,6 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
           }
         : {
             ...baseProps,
-            isSelect: true,
             placeholder,
             disabled,
             toggle: (downshift, isOpen) => {

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -88,8 +88,10 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
                 className: classNames(
                   "input_withClearButton",
                   {
-                    input_left: position === "left",
-                    input_right: position === "right",
+                    "input_left hover:z-1 hover:transition hover:duration-200 focus:z-1":
+                      position === "left",
+                    "input_right -ml-1 hover:z-1 hover:transition hover:duration-200 focus:z-1":
+                      position === "right",
                   },
                   "select",
                   selectClasses(isOpen)
@@ -134,8 +136,10 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
                 className: classNames(
                   "w-12/12 text-left select-toggle input_withClearButton",
                   {
-                    input_left: position === "left",
-                    input_right: position === "right",
+                    "input_left hover:z-1 hover:transition hover:duration-200 focus:z-1":
+                      position === "left",
+                    "input_right -ml-1 hover:z-1 hover:transition hover:duration-200 focus:z-1":
+                      position === "right",
                   },
                   "select",
                   selectClasses(isOpen),

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -24,7 +24,7 @@ interface BaseProps<T> {
   required?: boolean
   placeholder?: string
   hint?: string
-  className?: string
+  position?: "left" | "right"
   skipContainer?: boolean
 }
 
@@ -61,7 +61,7 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
       required = false,
       placeholder,
       hint,
-      className,
+      position,
       skipContainer = false,
       ...rest
     },
@@ -87,7 +87,10 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
                 ref,
                 className: classNames(
                   "input_withClearButton",
-                  className,
+                  {
+                    input_left: position === "left",
+                    input_right: position === "right",
+                  },
                   "select",
                   selectClasses(isOpen)
                 ),
@@ -130,7 +133,10 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
               const toggleProps = {
                 className: classNames(
                   "w-12/12 text-left select-toggle input_withClearButton",
-                  className,
+                  {
+                    input_left: position === "left",
+                    input_right: position === "right",
+                  },
                   "select",
                   selectClasses(isOpen),
                   {

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -71,7 +71,8 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
       options,
       onSelect: handleChange,
       selected,
-      menuClassName: hint ? "-mt-selectWithHintMenu" : "-mt-selectMenu",
+      hasHint: hint ? true : false,
+      //menuClassName: hint ? "-mt-selectWithHintMenu" : "-mt-selectMenu",
     }
 
     const dropdownProps =

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -75,7 +75,6 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
         hint && "withAutosuggest" in rest && rest.withAutosuggest
           ? true
           : false,
-      //menuClassName: hint ? "-mt-selectWithHintMenu" : "-mt-selectMenu",
     }
 
     const dropdownProps =

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -71,10 +71,7 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
       options,
       onSelect: handleChange,
       selected,
-      hasHint:
-        hint && "withAutosuggest" in rest && rest.withAutosuggest
-          ? true
-          : false,
+      hasHint: hint ? true : false,
     }
 
     const dropdownProps =
@@ -130,6 +127,7 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
           }
         : {
             ...baseProps,
+            isSelect: true,
             placeholder,
             disabled,
             toggle: (downshift, isOpen) => {

--- a/src/stories/select/withAutosuggest/appearance.stories.js
+++ b/src/stories/select/withAutosuggest/appearance.stories.js
@@ -55,28 +55,14 @@ const Template = (args) => {
             </div>
           </div>
         ) : (
-          <div>
-            <div className="mr-20 mt-20">
-              <Select
-                {...args}
-                selected={value}
-                handleChange={(v) => {
-                  setValue(v)
-                  handleChange()(v)
-                }}
-              />
-            </div>
-            <div className="ml-20 mt-20">
-              <Select
-                {...args}
-                selected={value}
-                handleChange={(v) => {
-                  setValue(v)
-                  handleChange()(v)
-                }}
-              />
-            </div>
-          </div>
+          <Select
+            {...args}
+            selected={value}
+            handleChange={(v) => {
+              setValue(v)
+              handleChange()(v)
+            }}
+          />
         )
       }
     />

--- a/src/stories/select/withAutosuggest/appearance.stories.js
+++ b/src/stories/select/withAutosuggest/appearance.stories.js
@@ -55,14 +55,28 @@ const Template = (args) => {
             </div>
           </div>
         ) : (
-          <Select
-            {...args}
-            selected={value}
-            handleChange={(v) => {
-              setValue(v)
-              handleChange()(v)
-            }}
-          />
+          <div>
+            <div className="mr-20 mt-20">
+              <Select
+                {...args}
+                selected={value}
+                handleChange={(v) => {
+                  setValue(v)
+                  handleChange()(v)
+                }}
+              />
+            </div>
+            <div className="ml-20 mt-20">
+              <Select
+                {...args}
+                selected={value}
+                handleChange={(v) => {
+                  setValue(v)
+                  handleChange()(v)
+                }}
+              />
+            </div>
+          </div>
         )
       }
     />

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -318,6 +318,7 @@ export default {
     */
 
     margin: {
+      "-1": "-1px",
       auto: "auto",
       px: "1px",
       "0": "0",
@@ -525,6 +526,7 @@ export default {
     |
     */
     zIndex: {
+      1: 1,
       auto: "auto",
       negative: -1,
       clearButton: 10,

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -627,7 +627,7 @@ export default {
     whitespace: ["responsive"],
     width: ["responsive"],
     wordBreak: ["responsive"],
-    zIndex: ["responsive"],
+    zIndex: ["responsive", "hover", "focus"],
     gap: ["responsive"],
     scale: ["responsive", "hover", "focus"],
     translate: ["responsive", "hover", "focus"],


### PR DESCRIPTION
Reference: [CFYEO-39](https://autoricardo.atlassian.net/browse/CFYEO-39)

Some components provided the ability to pass classes as a prop. This gives the consumer of that component a lot of possibilities to mess around with the styling. Therefore, I removed them where possible.

Unfortunately, I was not able to remove the menuClassName prop as it will require a lot of restructuring or inventing new boolean props to achieve the same styling. However, I think this change provides a bit of value nevertheless as it improves consistency and does not allow className in other places now.

----

Here are the related PR's:
- dealerhub: https://github.com/carforyou/carforyou-dealerhub-web/pull/894
- listings: https://github.com/carforyou/carforyou-listings-web/pull/2801
- header-footer: not affected by this change
- content-web: not affected by this change
- email-templates: not affected by this change
 
----

The following was discussed and approved with the UX designer:

1. Shadow hard on full-screen dropdowns -> aligned with the dropdown of autosuggest fields
Before:
![image](https://user-images.githubusercontent.com/71456764/104005243-1cd35e00-51a5-11eb-8bea-f0441a57c975.png)

Now:
![image](https://user-images.githubusercontent.com/71456764/104005259-20ff7b80-51a5-11eb-9f98-7a881a99e422.png)

2. Added border-radius to full-screen dropdowns
Before:
![image](https://user-images.githubusercontent.com/71456764/104005318-38d6ff80-51a5-11eb-9f74-2d65861c3b77.png)

Now:
![image](https://user-images.githubusercontent.com/71456764/104005324-3d031d00-51a5-11eb-87ed-c20db2e6aa13.png)

(you have to look very closely and it's not that obvious)