### PR TITLE
fix: make the onChange event compatible with default input on change event

### DIFF
--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -1,4 +1,9 @@
-import React, { FocusEvent, forwardRef, KeyboardEvent } from "react"
+import React, {
+  ChangeEvent,
+  FocusEvent,
+  forwardRef,
+  KeyboardEvent,
+} from "react"
 import classNames from "classnames"
 
 import InputField from "./inputField"
@@ -19,8 +24,16 @@ interface InputProps {
   hasClearButton?: boolean
   hasSearchIcon?: boolean
   mode: "text" | "numeric" | "decimal" | "tel" | "email"
-  onChange: <T extends { target: { name: string; value: string | number } }>(
-    e: T
+  onChange: (
+    e:
+      | ChangeEvent<HTMLInputElement>
+      | {
+          target: {
+            name: string
+            value: string | number
+            cleared: boolean
+          }
+        }
   ) => void
   onBlur?: (e: FocusEvent) => void
   onKeyDown?: (e: KeyboardEvent) => void

--- a/src/components/input/inputField.tsx
+++ b/src/components/input/inputField.tsx
@@ -61,7 +61,7 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
   hasError?: string
   disabled?: boolean
   required?: boolean
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
   onBlur?: (e: FocusEvent) => void
   debounce?: number
 }

--- a/src/components/input/inputField.tsx
+++ b/src/components/input/inputField.tsx
@@ -1,4 +1,9 @@
-import React, { FocusEvent, forwardRef, InputHTMLAttributes } from "react"
+import React, {
+  ChangeEvent,
+  FocusEvent,
+  forwardRef,
+  InputHTMLAttributes,
+} from "react"
 
 import debounceCallback from "../../lib/debounceHelper"
 
@@ -56,7 +61,7 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
   hasError?: string
   disabled?: boolean
   required?: boolean
-  onChange?: (e: { target: { value: string | number } }) => void
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
   onBlur?: (e: FocusEvent) => void
   debounce?: number
 }


### PR DESCRIPTION
Makes the onChange event compatible with the default onChange event yielded by an input filed.

Use Case: We want to ad an input mask that formats the input for the user, the input mask library is submitting a `ChangeEvent<HTMLInputElement>` event, with the current typing the component can not be used as a wrapper ref: https://github.com/carforyou/carforyou-listings-web/pull/2861/files

