### PR TITLE
feat: make segmented control grow

### DIFF
--- a/src/components/segmentedControl/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/segmentedControl/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SegmentedControl> renders a div tag for a custom renderer with link 1`] = `
 <div
-  class="flex w-12/12 justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-b-2 border-r-2 focus:outline-none bg-transparent text-teal border-teal focus:shadow-focus rounded-none hover:bg-teal-light active:bg-teal-bright"
+  class="flex justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-b-2 border-r-2 focus:outline-none bg-transparent text-teal w-12/12 border-teal focus:shadow-focus rounded-none hover:bg-teal-light active:bg-teal-bright"
 >
   <a
     class="w-12/12 hover:opacity-100 flex flex-col"

--- a/src/components/segmentedControl/button.tsx
+++ b/src/components/segmentedControl/button.tsx
@@ -8,6 +8,7 @@ interface Props {
   selected?: boolean
   disabled?: boolean
   small?: boolean
+  growing?: boolean
   position: "left" | "right" | "middle"
   onClick?: () => void
 }
@@ -18,6 +19,7 @@ export const Button: FC<Props> = ({
   disabled,
   selected,
   onClick,
+  growing,
   position,
 }) => {
   const padding = classnames("px-8", small ? "py-8" : "py-16")
@@ -26,8 +28,9 @@ export const Button: FC<Props> = ({
   return createElement(isWrapped ? "div" : "button", {
     ...(!isWrapped ? { type: "button" } : {}),
     className: classnames(
-      "flex w-12/12 justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-b-2 border-r-2 focus:outline-none",
+      "flex justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-b-2 border-r-2 focus:outline-none",
       selected ? "bg-teal text-white" : "bg-transparent text-teal",
+      growing ? "flex-grow" : "w-12/12",
       disabled
         ? "cursor-not-allowed border-grey-3 bg-grey-1 text-grey-4 hover:border-grey-3 hover:bg-grey-1"
         : "border-teal focus:shadow-focus",

--- a/src/components/segmentedControl/index.tsx
+++ b/src/components/segmentedControl/index.tsx
@@ -30,6 +30,7 @@ interface Props<T> {
    */
   small?: boolean
   disabled?: boolean
+  growing?: boolean
 }
 
 function SegmentedControl<T>({
@@ -39,6 +40,7 @@ function SegmentedControl<T>({
   renderOption = ({ name }) => name,
   small = false,
   disabled = false,
+  growing = false,
 }: Props<T>): ReactElement {
   const [selectedValue, updateSelected] = useState(
     (options.find(({ value }) => value === initialSelection) || options[0])
@@ -56,6 +58,7 @@ function SegmentedControl<T>({
             selected={selected}
             disabled={disabled}
             small={small}
+            growing={growing}
             position={
               index === 0 ? "left" : index === lastOption ? "right" : "middle"
             }

--- a/src/stories/segmentedControl.stories.tsx
+++ b/src/stories/segmentedControl.stories.tsx
@@ -18,6 +18,7 @@ const onSelect = () => action("onSelect")
 const initialSelection = (initial = null) => initial
 const small = (initial = false) => initial
 const disabled = (initial = false) => initial
+const growing = (initial = false) => initial
 
 export default {
   title: "Segmented Control",
@@ -40,7 +41,7 @@ const Template: FC<Props> = (args) => {
   return (
     <StoryContainer
       title={args.storyName}
-      style={"w-12/12 md:w-4/12"}
+      style={"w-12/12 md:w-6/12"}
       component={<SegmentedControl {...args} />}
     />
   )
@@ -53,6 +54,7 @@ Default.args = {
   initialSelection: initialSelection(),
   small: small(),
   disabled: disabled(),
+  growing: growing(),
 }
 
 export const WithTwoButtons = Template.bind({})
@@ -131,4 +133,19 @@ DisabledSmall.args = {
   initialSelection: initialSelection(),
   small: small(true),
   disabled: disabled(true),
+}
+
+export const Growing = Template.bind({})
+Growing.args = {
+  storyName: "Growing",
+  options: [
+    { value: 1, name: "Button 1" },
+    { value: 2, name: "Button with very long text" },
+    { value: 3, name: "Button with even longer text" },
+  ],
+  onSelect: onSelect(),
+  initialSelection: initialSelection(),
+  small: small(true),
+  disabled: disabled(),
+  growing: growing(true),
 }


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/CAR-6411

Currently all the segments are the same width, regardless of text content, which can lead to one segment being multiple lines. 
There are cases when we want to have dynamic width.

Before:
<img width="735" alt="Screenshot 2021-02-22 at 12 18 10" src="https://user-images.githubusercontent.com/5435020/108701435-3e479980-7508-11eb-8605-fb517987e891.png">
<img width="468" alt="Screenshot 2021-02-22 at 12 17 22" src="https://user-images.githubusercontent.com/5435020/108701439-3f78c680-7508-11eb-899f-ec9dd196d215.png">

After:
<img width="740" alt="Screenshot 2021-02-22 at 12 16 52" src="https://user-images.githubusercontent.com/5435020/108701488-53bcc380-7508-11eb-9953-dd670f03e5b7.png">
