### PR TITLE
feat: menu components

### DIFF
--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -217,6 +217,7 @@ Object {
     "letterSpacing": Object {
       "normal": "0",
       "wide": "1px",
+      "wider": "2px",
     },
     "lineHeight": Object {
       "label": "24px",

--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -183,6 +183,7 @@ Object {
       "sm": "14px",
       "xl": "24px",
       "xs": "12px",
+      "xxs": "10px",
     },
     "fontWeight": Object {
       "bold": 700,

--- a/src/components/datePicker/index.tsx
+++ b/src/components/datePicker/index.tsx
@@ -26,6 +26,7 @@ interface Props {
   labelText?: string
   minDate?: Date
   maxDate?: Date
+  disabled?: boolean
   formik: {
     name: string
     value: null | Date
@@ -40,6 +41,7 @@ const DatePicker: FC<Props> = ({
   labelText,
   minDate = null,
   maxDate = null,
+  disabled = false,
   formik: {
     value: initialValue = null,
     callback: updateFormValue,
@@ -94,6 +96,7 @@ const DatePicker: FC<Props> = ({
         }}
         hasClearButton={!isToday(selectedDate)}
         error={errorMessage}
+        disabled={disabled}
       />
 
       {showCalendar ? (

--- a/src/components/menu/element.tsx
+++ b/src/components/menu/element.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from "react"
+
+import MenuSectionTitle, { MenuSectionTitleProps } from "./sectionTitle"
+import MenuItem, { MenuItemProps } from "./item"
+
+interface TaggedMenuItemProps extends MenuItemProps {
+  tag: "item"
+}
+
+interface TaggedMenuSectionTitleProps extends MenuSectionTitleProps {
+  tag: "title"
+}
+
+type Props = TaggedMenuItemProps | TaggedMenuSectionTitleProps
+
+const MenuElement: FC<Props> = (props) => {
+  switch (props.tag) {
+    case "item":
+      return <MenuItem {...props} />
+    case "title":
+      return <MenuSectionTitle {...props} />
+  }
+}
+
+export default MenuElement
+export { Props as MenuElementProps }

--- a/src/components/menu/item.tsx
+++ b/src/components/menu/item.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, FC } from "react"
+import React, { ComponentType, FC, Fragment } from "react"
 import classNames from "classnames"
 
 interface Props {
@@ -22,6 +22,10 @@ interface Props {
    * marks the item as active in the UI
    */
   active?: boolean
+  /**
+   * component to wrap the link with
+   */
+  LinkWrapper?: ComponentType<{ href?: string }>
 }
 
 const MenuItem: FC<Props> = ({
@@ -30,24 +34,27 @@ const MenuItem: FC<Props> = ({
   onClick,
   url,
   active = false,
+  LinkWrapper = Fragment,
 }) => {
   return (
-    <a
-      className={classNames("flex items-center py-13 pl-25 cursor-pointer", {
-        "bg-teal-light text-teal rounded-4 font-bold": active,
-      })}
-      onClick={onClick}
-      href={url}
-    >
-      <span
-        className={classNames("mr-10 text-base leading-sm", {
-          "text-grey-4": !active,
+    <LinkWrapper href={url}>
+      <a
+        className={classNames("flex items-center py-13 pl-25 cursor-pointer", {
+          "bg-teal-light text-teal rounded-4 font-bold": active,
         })}
+        onClick={onClick}
+        href={url}
       >
-        <IconComponent width="24px" height="24px" />
-      </span>
-      {title}
-    </a>
+        <span
+          className={classNames("mr-10 text-base leading-sm", {
+            "text-grey-4": !active,
+          })}
+        >
+          <IconComponent width="24px" height="24px" />
+        </span>
+        {title}
+      </a>
+    </LinkWrapper>
   )
 }
 

--- a/src/components/menu/item.tsx
+++ b/src/components/menu/item.tsx
@@ -1,0 +1,38 @@
+import React, { ComponentType, FC } from "react"
+
+interface Props {
+  /**
+   * title to be displayed
+   */
+  text: string
+  /**
+   * icon component to be rendered
+   */
+  IconComponent: ComponentType<{ width: string; height: string }>
+  /**
+   * click event handler (e.g. displaying modal, tracking function)
+   */
+  onClick?: () => void
+  /**
+   * url to navigate to
+   */
+  url?: string
+}
+
+const MenuItem: FC<Props> = ({ text, IconComponent, onClick, url }) => {
+  return (
+    <a
+      className="flex items-center py-13 cursor-pointer"
+      onClick={onClick}
+      href={url}
+    >
+      <span className="text-grey-4 mr-10">
+        <IconComponent width="24px" height="24px" />
+      </span>
+      {text}
+    </a>
+  )
+}
+
+export default MenuItem
+export { Props as MenuItemProps }

--- a/src/components/menu/item.tsx
+++ b/src/components/menu/item.tsx
@@ -34,7 +34,7 @@ const MenuItem: FC<Props> = ({
   return (
     <a
       className={classNames("flex items-center py-13 pl-25 cursor-pointer", {
-        "bg-teal-bright text-teal rounded-4 font-bold": active,
+        "bg-teal-light text-teal rounded-4 font-bold": active,
       })}
       onClick={onClick}
       href={url}

--- a/src/components/menu/item.tsx
+++ b/src/components/menu/item.tsx
@@ -4,7 +4,7 @@ interface Props {
   /**
    * title to be displayed
    */
-  text: string
+  title: string
   /**
    * icon component to be rendered
    */
@@ -19,7 +19,7 @@ interface Props {
   url?: string
 }
 
-const MenuItem: FC<Props> = ({ text, IconComponent, onClick, url }) => {
+const MenuItem: FC<Props> = ({ title, IconComponent, onClick, url }) => {
   return (
     <a
       className="flex items-center py-13 cursor-pointer"
@@ -29,7 +29,7 @@ const MenuItem: FC<Props> = ({ text, IconComponent, onClick, url }) => {
       <span className="text-grey-4 mr-10">
         <IconComponent width="24px" height="24px" />
       </span>
-      {text}
+      {title}
     </a>
   )
 }

--- a/src/components/menu/item.tsx
+++ b/src/components/menu/item.tsx
@@ -26,7 +26,7 @@ const MenuItem: FC<Props> = ({ title, IconComponent, onClick, url }) => {
       onClick={onClick}
       href={url}
     >
-      <span className="text-grey-4 mr-10">
+      <span className="text-grey-4 mr-10 text-base leading-sm">
         <IconComponent width="24px" height="24px" />
       </span>
       {title}

--- a/src/components/menu/item.tsx
+++ b/src/components/menu/item.tsx
@@ -1,4 +1,5 @@
 import React, { ComponentType, FC } from "react"
+import classNames from "classnames"
 
 interface Props {
   /**
@@ -17,16 +18,32 @@ interface Props {
    * url to navigate to
    */
   url?: string
+  /**
+   * marks the item as active in the UI
+   */
+  active?: boolean
 }
 
-const MenuItem: FC<Props> = ({ title, IconComponent, onClick, url }) => {
+const MenuItem: FC<Props> = ({
+  title,
+  IconComponent,
+  onClick,
+  url,
+  active = false,
+}) => {
   return (
     <a
-      className="flex items-center py-13 cursor-pointer"
+      className={classNames("flex items-center py-13 pl-25 cursor-pointer", {
+        "bg-teal-bright text-teal rounded-4 font-bold": active,
+      })}
       onClick={onClick}
       href={url}
     >
-      <span className="text-grey-4 mr-10 text-base leading-sm">
+      <span
+        className={classNames("mr-10 text-base leading-sm", {
+          "text-grey-4": !active,
+        })}
+      >
         <IconComponent width="24px" height="24px" />
       </span>
       {title}

--- a/src/components/menu/item.tsx
+++ b/src/components/menu/item.tsx
@@ -25,7 +25,7 @@ interface Props {
   /**
    * component to wrap the link with
    */
-  LinkWrapper?: ComponentType<{ href?: string }>
+  LinkWrapper?: ComponentType<{ href: string }>
 }
 
 const MenuItem: FC<Props> = ({

--- a/src/components/menu/sectionTitle.tsx
+++ b/src/components/menu/sectionTitle.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const MenuSectionTitle: FC<Props> = ({ title }) => {
   return (
-    <div className="uppercase font-bold text-xs leading-xs text-grey-3 tracking-wider mt-25">
+    <div className="uppercase font-bold text-xxs leading-xs text-grey-3 tracking-wider mt-25">
       {title}
     </div>
   )

--- a/src/components/menu/sectionTitle.tsx
+++ b/src/components/menu/sectionTitle.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from "react"
+
+interface Props {
+  /**
+   * title to be displayed
+   */
+  title: string
+}
+
+const MenuSectionTitle: FC<Props> = ({ title }) => {
+  return (
+    <div className="uppercase font-bold text-xs leading-xs text-grey-3 tracking-wider mt-25">
+      {title}
+    </div>
+  )
+}
+
+export default MenuSectionTitle
+export { Props as MenuSectionTitleProps }

--- a/src/components/menu/sectionTitle.tsx
+++ b/src/components/menu/sectionTitle.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const MenuSectionTitle: FC<Props> = ({ title }) => {
   return (
-    <div className="uppercase font-bold text-xxs leading-xs text-grey-3 tracking-wider mt-25">
+    <div className="uppercase font-bold text-xxs leading-xs text-grey-3 tracking-wider mt-25 pl-25">
       {title}
     </div>
   )

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -93,7 +93,7 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
                     "input_right -ml-1 hover:z-1 hover:transition hover:duration-200 focus:z-1":
                       position === "right",
                   },
-                  "select",
+                  "select bg-white",
                   selectClasses(isOpen)
                 ),
                 name,
@@ -141,7 +141,7 @@ const Select = forwardRef<HTMLInputElement, Props<any>>(
                     "input_right -ml-1 hover:z-1 hover:transition hover:duration-200 focus:z-1":
                       position === "right",
                   },
-                  "select",
+                  "select bg-white",
                   selectClasses(isOpen),
                   {
                     "select-toggle_disabled": disabled,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import Pagination from "./components/pagination"
 import OpeningHours from "./components/openingHours"
 import MenuSectionTitle from "./components/menu/sectionTitle"
 import MenuItem from "./components/menu/item"
+import MenuElement, { MenuElementProps } from "./components/menu/element"
 import Intercom from "./components/intercom/index"
 import Input from "./components/input/index"
 import Profile from "./components/icons/profile"
@@ -68,4 +69,6 @@ export {
   InputFilter,
   MenuItem,
   MenuSectionTitle,
+  MenuElement,
+  MenuElementProps,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import PreviewCard from "./components/previewCard/index"
 import Pill from "./components/pill"
 import Pagination from "./components/pagination"
 import OpeningHours from "./components/openingHours"
+import MenuSectionTitle from "./components/menu/sectionTitle"
+import MenuItem from "./components/menu/item"
 import Intercom from "./components/intercom/index"
 import Input from "./components/input/index"
 import Profile from "./components/icons/profile"
@@ -64,4 +66,6 @@ export {
   Locale,
   CheckboxFilter,
   InputFilter,
+  MenuItem,
+  MenuSectionTitle,
 }

--- a/src/stories/menu/item.stories.tsx
+++ b/src/stories/menu/item.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: "Menu/Item",
   component: MenuItem,
   args: {
-    text: "Menu item",
+    title: "Menu item",
     IconComponent: ProfileIcon,
     onClick: action("on click menu item"),
     url: "https://example.com",

--- a/src/stories/menu/item.stories.tsx
+++ b/src/stories/menu/item.stories.tsx
@@ -14,6 +14,7 @@ export default {
     IconComponent: ProfileIcon,
     onClick: action("on click menu item"),
     url: "https://example.com",
+    active: false,
   },
   argTypes: {
     storyName: {
@@ -41,4 +42,10 @@ const Template: FC<Props> = (args) => {
 export const Default = Template.bind({})
 Default.args = {
   storyName: "Default",
+}
+
+export const Active = Template.bind({})
+Active.args = {
+  storyName: "Active",
+  active: true,
 }

--- a/src/stories/menu/item.stories.tsx
+++ b/src/stories/menu/item.stories.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from "react"
+import { action } from "@storybook/addon-actions"
+
+import { StoryProps } from "../storyProps"
+import StoryContainer from "../storyContainer"
+import MenuItem, { MenuItemProps } from "../../components/menu/item"
+import ProfileIcon from "../../components/icons/profile"
+
+export default {
+  title: "Menu/Item",
+  component: MenuItem,
+  args: {
+    text: "Menu item",
+    IconComponent: ProfileIcon,
+    onClick: action("on click menu item"),
+    url: "https://example.com",
+  },
+  argTypes: {
+    storyName: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+}
+
+interface Props extends StoryProps<unknown>, MenuItemProps {
+  text: string
+}
+
+const Template: FC<Props> = (args) => {
+  return (
+    <StoryContainer
+      title={args.storyName}
+      style={"w-12/12"}
+      component={<MenuItem {...args} />}
+    />
+  )
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  storyName: "Default",
+}

--- a/src/stories/menu/sectionTitle.stories.tsx
+++ b/src/stories/menu/sectionTitle.stories.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from "react"
+
+import { StoryProps } from "../storyProps"
+import StoryContainer from "../storyContainer"
+import MenuSectionTitle, {
+  MenuSectionTitleProps,
+} from "../../components/menu/sectionTitle"
+
+export default {
+  title: "Menu/SectionTitle",
+  component: MenuSectionTitle,
+  args: {
+    title: "Menu section title",
+  },
+  argTypes: {
+    storyName: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+}
+
+interface Props extends StoryProps<unknown>, MenuSectionTitleProps {
+  text: string
+}
+
+const Template: FC<Props> = (args) => {
+  return (
+    <StoryContainer
+      title={args.storyName}
+      style={"w-12/12"}
+      component={<MenuSectionTitle {...args} />}
+    />
+  )
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  storyName: "Default",
+}

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -284,6 +284,7 @@ export default {
     letterSpacing: {
       normal: "0",
       wide: "1px",
+      wider: "2px",
     },
 
     /*

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -200,6 +200,7 @@ export default {
     */
     fontSize: {
       "0": "0px",
+      xxs: "10px",
       xs: "12px",
       sm: "14px",
       base: "16px",


### PR DESCRIPTION
Extracts `MenuItem` and `MenuSectionTitle` components introduced in carforyou/carforyou-header-footer-pkg#112 so that we can use the same basis to create sidebar menu in dealer-hub.