### PR TITLE
fix: menu item key

### DIFF
--- a/src/components/dropdown/menu.tsx
+++ b/src/components/dropdown/menu.tsx
@@ -127,17 +127,15 @@ class Menu<T> extends Component<Props<T>> {
             padding
           )
 
-          const key =
-            item.key || typeof item.value === "object"
-              ? `item-${index}`
-              : item.value?.toString()
-
           return (
             // eslint-disable-next-line react/jsx-key
             <li
               data-testid={item.name}
               {...getItemProps({
-                key,
+                key:
+                  item.key ||
+                  (typeof item.value !== "object" && item.value.toString()) ||
+                  `item-${index}`,
                 item,
                 className: classNames(
                   "hover:bg-grey-bright transition duration-200 cursor-pointer",

--- a/src/components/dropdown/menu.tsx
+++ b/src/components/dropdown/menu.tsx
@@ -127,12 +127,17 @@ class Menu<T> extends Component<Props<T>> {
             padding
           )
 
+          const key =
+            item.key || typeof item.value === "object"
+              ? `item-${index}`
+              : item.value?.toString()
+
           return (
             // eslint-disable-next-line react/jsx-key
             <li
               data-testid={item.name}
               {...getItemProps({
-                key: item.key || item.value?.toString() || `item-${index}`,
+                key,
                 item,
                 className: classNames(
                   "hover:bg-grey-bright transition duration-200 cursor-pointer",


### PR DESCRIPTION
If the key is not defined on the options, it will use the value as the key. Because the value is often an object such as `{sortOrder: "ASC", sortType: "PRICE"}`, `value.toString()` will result in `[object Object]`.

As a result, the DOM is invalid because of duplicated keys

![image](https://user-images.githubusercontent.com/71456764/113994873-06957680-9856-11eb-85a5-8b361b3a21c5.png)
