### PR TITLE
fix: change <a/> to <div/> to allow links within the collapsible

### DIFF
--- a/src/components/collapsible.tsx
+++ b/src/components/collapsible.tsx
@@ -48,9 +48,9 @@ const Collapsible: FC<Props> = ({
 
   return (
     <>
-      <a
+      <div
         className={classNames("flex items-center cursor-pointer", {
-          "hover:opacity-100": !opacityOnHover,
+          "transition duration-200 hover:opacity-60": opacityOnHover,
         })}
         onClick={() => {
           onChange && onChange(!isCollapsed)
@@ -62,7 +62,7 @@ const Collapsible: FC<Props> = ({
           {renderToggle(isCollapsed)}
           <ArrowDownM className={isCollapsed ? null : "rotate-180 transform"} />
         </div>
-      </a>
+      </div>
       {alwaysRender ? (
         <div className={isCollapsed ? "hidden" : "block"}>{children()}</div>
       ) : isCollapsed ? null : (


### PR DESCRIPTION
Reference: [CAR-7124](https://autoricardo.atlassian.net/browse/CAR-7124)

In some pages in DH and listings, there is an error in the console that the DOM is invalid. The reason for it is that the collapsible itself is an `<a/>` tag. This does not allow to have other a tags within the collapsible component. As we have this requirement, I changed it here to a div.
![image](https://user-images.githubusercontent.com/71456764/114511787-a711df00-9c38-11eb-8626-6c6e5dff43d9.png)
