### PR TITLE
fix: add test id for collapsible

### DIFF
--- a/src/components/collapsible.tsx
+++ b/src/components/collapsible.tsx
@@ -57,6 +57,7 @@ const Collapsible: FC<Props> = ({
           setIsCollapsed(!isCollapsed)
         }}
         data-collapsed={isCollapsed}
+        data-testid="collapsible"
       >
         <div className="flex w-12/12 items-center">
           {renderToggle(isCollapsed)}


### PR DESCRIPTION
I missed one of the IT tests in listings that queried the `<a/>` tag. Because of the div, the selector is no longer possible because it found too many. 
I have a draft branch here with the fixed tests -> https://github.com/carforyou/carforyou-listings-web/pull/3090