### PR TITLE
fix: do not pass href prop to fragment

### DIFF
--- a/src/components/menu/item.tsx
+++ b/src/components/menu/item.tsx
@@ -25,7 +25,7 @@ interface Props {
   /**
    * component to wrap the link with
    */
-  LinkWrapper?: ComponentType<{ href: string }>
+  LinkWrapper?: ComponentType<{ href?: string }>
 }
 
 const MenuItem: FC<Props> = ({
@@ -34,10 +34,12 @@ const MenuItem: FC<Props> = ({
   onClick,
   url,
   active = false,
-  LinkWrapper = Fragment,
+  LinkWrapper,
 }) => {
+  const LinkWrapperComponent = LinkWrapper || Fragment
+
   return (
-    <LinkWrapper href={url}>
+    <LinkWrapperComponent {...(LinkWrapper ? { href: url } : {})}>
       <a
         className={classNames("flex items-center py-13 pl-25 cursor-pointer", {
           "bg-teal-light text-teal rounded-4 font-bold": active,
@@ -54,7 +56,7 @@ const MenuItem: FC<Props> = ({
         </span>
         {title}
       </a>
-    </LinkWrapper>
+    </LinkWrapperComponent>
   )
 }
 


### PR DESCRIPTION
In case the menu item doesn't have a link wrapper we pass `href` prop to `React.Fragment`.
This results in warnings from react:
<img width="572" alt="Screenshot 2021-04-23 at 10 08 50" src="https://user-images.githubusercontent.com/144707/115840397-ec45c600-a41b-11eb-8790-0db3e3ae33df.png">

## After
`href` prop is only passed when we don't use `Fragment` as default wrapper