### PR TITLE
fix: change padding

### DIFF
--- a/src/components/datePicker/index.module.css
+++ b/src/components/datePicker/index.module.css
@@ -12,12 +12,6 @@
     @apply shadow-hard rounded-6 bg-white leading-xs w-12/12 p-10;
 }
 
-@screen xxs {
-    :local .react-calendar {
-        min-width: 346px;
-    }
-}
-
 :local .react-calendar,
 :local .react-calendar *,
 :local .react-calendar *:before,

--- a/src/components/datePicker/index.module.css
+++ b/src/components/datePicker/index.module.css
@@ -12,6 +12,12 @@
     @apply shadow-hard rounded-6 bg-white leading-xs w-12/12 p-10;
 }
 
+@screen xxs {
+  :local .react-calendar {
+      min-width: 346px;
+  }
+}
+
 :local .react-calendar,
 :local .react-calendar *,
 :local .react-calendar *:before,

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -74,11 +74,11 @@ const Modal: FC<ModalProps> = ({
           <CloseMIcon color={style === "dark" ? "#FFFFFF" : "#232A36"} />
         </div>
         <div
-          className={classNames("z-modal w-12/12 my-0", {
-            "p-40 md:w-modalLarge": size === "large",
-            "p-40 md:w-modal": size === "medium",
-            "p-40 md:w-modalSmall": size === "small",
-            "h-full": size === "fullscreen",
+          className={classNames("z-modal w-12/12 my-0 p-15", {
+            "md:p-40 md:w-modalLarge": size === "large",
+            "md:p-40 md:w-modal": size === "medium",
+            "md:p-40 md:w-modalSmall": size === "small",
+            "md:p-0 h-full": size === "fullscreen",
           })}
         >
           {children({ closeModal: close })}

--- a/src/hooks/__tests__/__snapshots__/useModal.test.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/useModal.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`useModal with a portal renders the modal within the portal 1`] = `
         </svg>
       </div>
       <div
-        class="z-modal w-12/12 my-0 p-40 md:w-modal"
+        class="z-modal w-12/12 my-0 p-15 md:p-40 md:w-modal"
       >
         <div>
           HERE BE DRAGONS
@@ -115,7 +115,7 @@ exports[`useModal without portal renders the modal within the container 1`] = `
           </svg>
         </div>
         <div
-          class="z-modal w-12/12 my-0 p-40 md:w-modal"
+          class="z-modal w-12/12 my-0 p-15 md:p-40 md:w-modal"
         >
           <div>
             HERE BE DRAGONS


### PR DESCRIPTION
References [CAR-7194](https://autoricardo.atlassian.net/browse/CAR-7194)

## Motivation and context

On iPhone 7 and iPhone X, the Calendar for test drive request are more towards the right of the screen.

## How to test
Go to https://car7194.carforyou-listings-web.branch.carforyou.ch/
Check that the calendar is not wider than the input
