### PR TITLE
fix: align button style

### DIFF
--- a/src/components/__tests__/__snapshots__/button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/button.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Button> button variations renders disabled button 1`] = `
     class="flex flex-col"
   >
     <button
-      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-52 rounded border bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon bg-grey-1 hover:bg-grey-1 text-grey-4 cursor-not-allowed border-grey-1"
+      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-52 rounded border bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon cursor-not-allowed  bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4"
       disabled=""
       type="button"
     >
@@ -37,7 +37,7 @@ exports[`<Button> button variations renders small disabled button 1`] = `
     class="flex flex-col"
   >
     <button
-      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-36 rounded border bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon bg-grey-1 hover:bg-grey-1 text-grey-4 cursor-not-allowed border-grey-1"
+      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-36 rounded border bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon cursor-not-allowed  bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4"
       disabled=""
       type="button"
     >

--- a/src/components/__tests__/button.test.tsx
+++ b/src/components/__tests__/button.test.tsx
@@ -32,7 +32,7 @@ describe("<Button>", () => {
     })
 
     it("renders teal button", () => {
-      const { container } = render(<Button teal>Label</Button>)
+      const { container } = render(<Button style="teal">Label</Button>)
       expect(container).toMatchSnapshot()
     })
 
@@ -52,7 +52,7 @@ describe("<Button>", () => {
 
     it("renders small teal button", () => {
       const { container } = render(
-        <Button size="small" teal>
+        <Button size="small" style="teal">
           Label
         </Button>
       )
@@ -60,13 +60,13 @@ describe("<Button>", () => {
     })
 
     it("renders white Teal button", () => {
-      const { container } = render(<Button tealBorder>Label</Button>)
+      const { container } = render(<Button style="teal-border">Label</Button>)
       expect(container).toMatchSnapshot()
     })
 
     it("renders white Teal small button", () => {
       const { container } = render(
-        <Button tealBorder size="small">
+        <Button style="teal-border" size="small">
           Label
         </Button>
       )

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -7,8 +7,7 @@ interface Props {
   /** - */
   children: ReactNode
   dataTestid?: string
-  teal?: boolean
-  tealBorder?: boolean
+  style?: "salmon" | "teal" | "teal-border"
   size?: "large" | "small" | "responsive"
   disabled?: boolean
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void
@@ -25,9 +24,8 @@ interface Props {
 export const Button: FC<Props> = ({
   children,
   dataTestid,
-  teal,
-  tealBorder,
   size = "large",
+  style = "salmon",
   disabled,
   onClick,
   submit,
@@ -40,14 +38,15 @@ export const Button: FC<Props> = ({
     "min-h-36 lg:min-h-52": size === "responsive",
   })
   const classes = classnames("rounded border", {
-    "bg-teal hover:bg-teal-dark focus:bg-teal": teal,
-    "bg-white text-teal hover:opacity-60": tealBorder,
-    "border-teal": teal || tealBorder,
+    "bg-teal hover:bg-teal-dark focus:bg-teal border-teal": style === "teal",
+    "bg-white text-teal hover:opacity-60 border-teal": style === "teal-border",
     "bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon":
-      !teal && !tealBorder,
-    "text-grey-dark hover:opacity-100": disabled && tealBorder,
-    "bg-grey-1 hover:bg-grey-1 text-grey-4": disabled && !tealBorder,
-    "cursor-not-allowed border-grey-1": disabled,
+      style === "salmon",
+    "cursor-not-allowed ": disabled,
+    "bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4":
+      disabled && style !== "teal-border",
+    "text-grey-3 border-grey-3 hover:opacity-100":
+      disabled && style === "teal-border",
   })
   const buttonClasses = classnames(padding, classes)
 

--- a/src/stories/button.stories.tsx
+++ b/src/stories/button.stories.tsx
@@ -39,6 +39,12 @@ Default.args = {
   storyName: "Default",
 }
 
+export const Disabled = Template.bind({})
+Disabled.args = {
+  disabled: true,
+  storyName: "Disabled",
+}
+
 export const Small = Template.bind({})
 Small.args = {
   size: "small",
@@ -53,20 +59,28 @@ Responsive.args = {
 
 export const Teal = Template.bind({})
 Teal.args = {
-  teal: true,
+  style: "teal",
+  storyName: "Teal",
+}
+
+export const TealDisabled = Template.bind({})
+TealDisabled.args = {
+  style: "teal",
+  disabled: true,
   storyName: "Teal",
 }
 
 export const TealBorder = Template.bind({})
 TealBorder.args = {
-  tealBorder: true,
+  style: "teal-border",
   storyName: "Teal Border",
 }
 
-export const Disabled = Template.bind({})
-Disabled.args = {
+export const TealBorderDisabled = Template.bind({})
+TealBorderDisabled.args = {
+  style: "teal-border",
   disabled: true,
-  storyName: "Disabled",
+  storyName: "Teal Border",
 }
 
 export const WrappingALink = Template.bind({})


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/CAR-7219

Other than adding a new disabled style for a button with a teal border this PR fixes how we set button style.
Before this was controlled by boolean props `teal` and `tealBorder`, which could lead to setting an "impossible" style (by setting both to true). This has now been replaced by `style` prop which accepts `salmon` (default), `teal` and `teal-border`.

Because of this, it will be a BREAKING CHANGE.