### PR TITLE
feat: introduce tabs component

### DIFF
--- a/src/components/__tests__/tabs.test.tsx
+++ b/src/components/__tests__/tabs.test.tsx
@@ -8,19 +8,19 @@ const renderWrapper = () =>
     <Tabs
       tabs={[
         {
-          name: "Tab 1",
+          title: "Tab 1",
           renderContent: () => <>Tab 1 Content</>,
         },
         {
-          name: "Tab 2",
+          title: "Tab 2",
           renderContent: () => <>Tab 2 Content</>,
         },
         {
-          name: "Tab 3",
+          title: "Tab 3",
           renderContent: () => <>Tab 3 Content</>,
         },
         {
-          name: "Tab 4",
+          title: "Tab 4",
           renderContent: () => <>Tab 4 Content</>,
         },
       ]}

--- a/src/components/__tests__/tabs.test.tsx
+++ b/src/components/__tests__/tabs.test.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import { act, fireEvent, render, waitFor } from "@testing-library/react"
+
+import Tabs from "../tabs"
+
+const renderWrapper = () =>
+  render(
+    <Tabs
+      tabs={[
+        {
+          name: "Tab 1",
+          renderContent: () => <>Tab 1 Content</>,
+        },
+        {
+          name: "Tab 2",
+          renderContent: () => <>Tab 2 Content</>,
+        },
+        {
+          name: "Tab 3",
+          renderContent: () => <>Tab 3 Content</>,
+        },
+        {
+          name: "Tab 4",
+          renderContent: () => <>Tab 4 Content</>,
+        },
+      ]}
+    />
+  )
+
+describe("<Tabs />", () => {
+  it("opens first tab by default", () => {
+    const { getByText } = renderWrapper()
+
+    expect(getByText("Tab 1 Content"))
+  })
+
+  it("allows switching tabs", () => {
+    const { getByText } = renderWrapper()
+
+    act(() => {
+      fireEvent.click(getByText("Tab 2"))
+    })
+
+    return waitFor(() => {
+      getByText("Tab 2 Content")
+    })
+  })
+})

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode, useState } from "react"
 import classnames from "classnames"
 
 interface Tab {
-  name: string
+  title: string
   renderIcon?: () => ReactNode
   renderContent: () => ReactNode
 }
@@ -19,7 +19,7 @@ const Tabs: FC<Props> = ({ tabs }) => {
   return (
     <div className="w-12/12 bg-white rounded-4 border border-grey-2 shadow-soft">
       <div className="flex flex-row">
-        {tabs.map(({ name, renderIcon }, index) => (
+        {tabs.map(({ title, renderIcon }, index) => (
           <div
             onClick={() => setActiveTab(index)}
             className={classnames(
@@ -34,7 +34,7 @@ const Tabs: FC<Props> = ({ tabs }) => {
             key={`tab-${index}`}
           >
             {renderIcon && <span className="pr-8">{renderIcon()}</span>}
-            {name}
+            {title}
           </div>
         ))}
       </div>

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -1,0 +1,47 @@
+import React, { FC, ReactNode, useState } from "react"
+import classnames from "classnames"
+
+interface Tab {
+  name: string
+  renderIcon?: () => ReactNode
+  renderContent: () => ReactNode
+}
+
+interface Props {
+  tabs: Tab[]
+}
+
+const Tabs: FC<Props> = ({ tabs }) => {
+  const [activeTab, setActiveTab] = useState(0)
+
+  const tabsCount = tabs.length
+
+  return (
+    <div className="w-12/12 bg-white rounded-4 border border-grey-2 shadow-soft">
+      <div className="flex flex-row">
+        {tabs.map(({ name, renderIcon }, index) => (
+          <div
+            onClick={() => setActiveTab(index)}
+            className={classnames(
+              "flex items-center flex-1 p-14 text-grey-dark font-bold border-grey-2 cursor-pointer",
+              {
+                "bg-grey-1 border-b": index !== activeTab,
+                "border-r": index !== tabsCount - 1,
+                "justify-start": tabsCount === 1,
+                "justify-center": tabsCount > 1,
+              }
+            )}
+            key={`tab-${index}`}
+          >
+            {renderIcon && <span className="pr-8">{renderIcon()}</span>}
+            {name}
+          </div>
+        ))}
+      </div>
+      <div className="p-16">{tabs[activeTab].renderContent()}</div>
+    </div>
+  )
+}
+
+export { Props as TabsProps }
+export default Tabs

--- a/src/stories/tabs.stories.tsx
+++ b/src/stories/tabs.stories.tsx
@@ -39,7 +39,7 @@ Single.args = {
   storyName: "Single",
   tabs: [
     {
-      name: "Tab 1",
+      title: "Tab 1",
       renderContent: () => <>Tab 1 Content</>,
     },
   ],
@@ -47,15 +47,15 @@ Single.args = {
 
 export const WithIcon = Template.bind({})
 WithIcon.args = {
-  storyName: "With Icon",
+  storytitle: "With Icon",
   tabs: [
     {
-      name: "Tab 1",
+      title: "Tab 1",
       renderContent: () => <>Tab 1 Content</>,
       renderIcon: () => <MailSent width="20px" height="20px" />,
     },
     {
-      name: "Tab 2",
+      title: "Tab 2",
       renderContent: () => <>Tab 2 Content</>,
       renderIcon: () => <MailSent width="20px" height="20px" />,
     },
@@ -64,22 +64,22 @@ WithIcon.args = {
 
 export const More = Template.bind({})
 More.args = {
-  storyName: "More tabs",
+  storytitle: "More tabs",
   tabs: [
     {
-      name: "Tab 1",
+      title: "Tab 1",
       renderContent: () => <>Tab 1 Content</>,
     },
     {
-      name: "Tab 2",
+      title: "Tab 2",
       renderContent: () => <>Tab 2 Content</>,
     },
     {
-      name: "Tab 3",
+      title: "Tab 3",
       renderContent: () => <>Tab 3 Content</>,
     },
     {
-      name: "Tab 4",
+      title: "Tab 4",
       renderContent: () => <>Tab 4 Content</>,
     },
   ],

--- a/src/stories/tabs.stories.tsx
+++ b/src/stories/tabs.stories.tsx
@@ -1,0 +1,86 @@
+import React, { FC } from "react"
+
+import { StoryProps } from "./storyProps"
+import StoryContainer from "./storyContainer"
+import Tabs, { TabsProps } from "../components/tabs"
+import MailSent from "../../.storybook/icons/mailSent"
+
+export default {
+  title: "Tabs",
+  component: Tabs,
+  args: {
+    storyName: "",
+    tabs: [
+      { name: "Tab 1", renderContent: () => <>Tab 1 Content</> },
+      { name: "Tab 2", renderContent: () => <>Tab 2 Content</> },
+    ],
+  },
+  argTypes: {
+    storyName: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+}
+
+interface Props extends StoryProps<unknown>, TabsProps {}
+
+const Template: FC<Props> = (args) => {
+  return (
+    <StoryContainer title={args.storyName} component={<Tabs {...args} />} />
+  )
+}
+
+export const Default = Template.bind({})
+
+export const Single = Template.bind({})
+Single.args = {
+  storyName: "Single",
+  tabs: [
+    {
+      name: "Tab 1",
+      renderContent: () => <>Tab 1 Content</>,
+    },
+  ],
+}
+
+export const WithIcon = Template.bind({})
+WithIcon.args = {
+  storyName: "With Icon",
+  tabs: [
+    {
+      name: "Tab 1",
+      renderContent: () => <>Tab 1 Content</>,
+      renderIcon: () => <MailSent width="20px" height="20px" />,
+    },
+    {
+      name: "Tab 2",
+      renderContent: () => <>Tab 2 Content</>,
+      renderIcon: () => <MailSent width="20px" height="20px" />,
+    },
+  ],
+}
+
+export const More = Template.bind({})
+More.args = {
+  storyName: "More tabs",
+  tabs: [
+    {
+      name: "Tab 1",
+      renderContent: () => <>Tab 1 Content</>,
+    },
+    {
+      name: "Tab 2",
+      renderContent: () => <>Tab 2 Content</>,
+    },
+    {
+      name: "Tab 3",
+      renderContent: () => <>Tab 3 Content</>,
+    },
+    {
+      name: "Tab 4",
+      renderContent: () => <>Tab 4 Content</>,
+    },
+  ],
+}


### PR DESCRIPTION
Implements CAR-7324

This PR adds a new `Tabs` component:

**Single tab**
<img width="482" alt="Screenshot 2021-05-18 at 15 04 14" src="https://user-images.githubusercontent.com/144707/118655947-528af200-b7ea-11eb-85c5-de9f2e93c105.png">

**Multiple tabs**
<img width="394" alt="Screenshot 2021-05-18 at 15 04 01" src="https://user-images.githubusercontent.com/144707/118655910-4a32b700-b7ea-11eb-8dbf-f50e3d0e32f5.png">

**Tabs with icons**
<img width="388" alt="Screenshot 2021-05-18 at 15 05 00" src="https://user-images.githubusercontent.com/144707/118656036-6cc4d000-b7ea-11eb-97d9-20170ce7a01a.png">
