### PR TITLE
fix: tabs jumping issues

### DIFF
--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -28,6 +28,7 @@ const Tabs: FC<Props> = ({ tabs }) => {
                 "bg-grey-1 border-b": index !== activeTab,
                 "mb-px": index === activeTab,
                 "border-r": index !== tabsCount - 1,
+                "-ml-1 border-l": index !== 0,
                 "justify-start": tabsCount === 1,
                 "justify-center": tabsCount > 1,
               }

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -26,6 +26,7 @@ const Tabs: FC<Props> = ({ tabs }) => {
               "flex items-center flex-1 p-14 text-grey-dark font-bold border-grey-2 cursor-pointer",
               {
                 "bg-grey-1 border-b": index !== activeTab,
+                "mb-px": index === activeTab,
                 "border-r": index !== tabsCount - 1,
                 "justify-start": tabsCount === 1,
                 "justify-center": tabsCount > 1,


### PR DESCRIPTION
- due to the border being only rendered when the tab is not active text was jumping by 1px when switching between active/inactive. Since tailwind does not support variable border colours we fix it by adding margin when the tab is active
- the border separating tabs had corner pixel missing since it was only rendered on one side. Negative margin and rendering it on both sides fixes it.