### PR TITLE
fix(tooltip): stop event propagation

### DIFF
--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -38,7 +38,16 @@ const Tooltip: FC<Props> = ({
   alignment = TooltipAlignment.middle,
 }) => {
   return (
-    <div className="inline-block" onClick={(e) => e.preventDefault()}>
+    <div
+      className="inline-block"
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      }}
+      onTouchEnd={(e) => {
+        e.stopPropagation()
+      }}
+    >
       <TooltipTrigger
         content={
           <div className="rounded-4 shadow-hard p-15 bg-white">

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -38,19 +38,15 @@ const Tooltip: FC<Props> = ({
   alignment = TooltipAlignment.middle,
 }) => {
   return (
-    <div
-      className="inline-block"
-      onClick={(e) => {
-        e.preventDefault()
-        e.stopPropagation()
-      }}
-      onTouchEnd={(e) => {
-        e.stopPropagation()
-      }}
-    >
+    <div className="inline-block" onClick={(e) => e.preventDefault()}>
       <TooltipTrigger
         content={
-          <div className="rounded-4 shadow-hard p-15 bg-white">
+          <div
+            className="rounded-4 shadow-hard p-15 bg-white"
+            onTouchEnd={(e) => {
+              e.stopPropagation()
+            }}
+          >
             {renderContent()}
           </div>
         }


### PR DESCRIPTION
References CAR-7544 (https://autoricardo.atlassian.net/browse/CAR-7544)

## Motivation and context
1. in some cases we forget and then do retroactive fixes. I'd like to find a solution that works out of the box without having to apply weird event handlers in every single tooltip
2. I'd like to understand better where the need for this is coming from. preferrably, we would always let the events bubble and not prevent them. there might be a fix in the tooltip library for this by now

## Before
Explicitly stop event propagation every place `Tooltip` is used.

## After
Out of the box solution. event propagation is stopped in the `Tooltip` component 

## How to test
* open a consumer app where the components pkg is used  (i.e Dealerhub)
* open listings page on Dealerhub
* make sure you're on Mobile
* open verified badge
* click the link
* it should simply open the link in a new tab (without navigating to the listing details in the original tab)

## Note
I don't think we have other options but to stop events bubble. Because ulimately it will bubble up into DOM hierarchy and reach the list item (in this specific case) which would redirect to listings detail page.