### PR TITLE
fix: center labels in pagination

### DIFF
--- a/assets/pagination.css
+++ b/assets/pagination.css
@@ -11,7 +11,7 @@
 .page a {
   min-width: 30px;
   height: 30px;
-  @apply p-5 w-auto;
+  @apply w-auto;
 }
 
 .page:not(.active):hover {
@@ -20,7 +20,6 @@
 
 .page.active {
   @apply text-white bg-teal rounded-20 outline-none text-center;
-
 }
 
 .previous {
@@ -37,11 +36,11 @@
 }
 
 .page.active a {
-  @apply cursor-default opacity-100;
+  @apply cursor-default opacity-100 flex justify-center items-center;
 }
 
 .page a:link, .page a:visited {
-  @apply text-grey-dark;
+  @apply text-grey-dark flex justify-center items-center;
 }
 
 .page a:focus,
@@ -52,7 +51,7 @@
 }
 
 .next, .previous {
-  @apply mt-10;
+  @apply mt-20;
 }
 
 .next {


### PR DESCRIPTION
> Jira https://autoricardo.atlassian.net/browse/CAR-7480

## Before

The range page label is not centered either the number in the circle.

![Screenshot 2021-06-10 at 10 55 23](https://user-images.githubusercontent.com/37380787/121496101-72bd6380-c9da-11eb-8e92-0b7b4f2c48c9.png)

------------------------------------

![Screenshot 2021-06-10 at 16 06 54](https://user-images.githubusercontent.com/37380787/121539367-e88af480-ca05-11eb-9c0f-ea7a701747f2.png)



## After 

The range page label is centered either the number in the circle.

![Screenshot 2021-06-09 at 15 19 53](https://user-images.githubusercontent.com/37380787/121494318-ed857f00-c9d8-11eb-98b4-5b8f9eddebbe.png)

----------------------------

![Screenshot 2021-06-10 at 15 52 22](https://user-images.githubusercontent.com/37380787/121537931-aa410580-ca04-11eb-8460-d66512431604.png)


## How to test
Please check it on mobile and desktop

You can see the results from listings here:
https://car-7480.carforyou-listings-web.branch.carforyou.ch/en/auto/mercedes-benz

https://car-7480.carforyou-listings-web.branch.carforyou.ch/en/auto/search

# Thank you 🛠