### PR TITLE
fix: badges behaviour for various usecases

### DIFF
--- a/src/components/badges/base.tsx
+++ b/src/components/badges/base.tsx
@@ -19,7 +19,7 @@ const BaseBadge: FC<Props> = ({ icon, text, size, tooltipContent }) => {
     <div
       className={classNames(
         styles.space,
-        "inline-flex items-center border border-grey-1 rounded-4 text-sm font-bold",
+        "inline-flex items-center border border-grey-1 rounded-4 text-sm font-bold bg-white",
         {
           "cursor-pointer": tooltipContent,
         }

--- a/src/components/badges/base.tsx
+++ b/src/components/badges/base.tsx
@@ -19,7 +19,10 @@ const BaseBadge: FC<Props> = ({ icon, text, size, tooltipContent }) => {
     <div
       className={classNames(
         styles.space,
-        "inline-flex items-center border border-grey-1 rounded-4 cursor-pointer text-sm font-bold"
+        "inline-flex items-center border border-grey-1 rounded-4 text-sm font-bold",
+        {
+          "cursor-pointer": tooltipContent,
+        }
       )}
     >
       {icon}

--- a/src/components/badges/buyerProtection.tsx
+++ b/src/components/badges/buyerProtection.tsx
@@ -15,17 +15,20 @@ export const BuyerProtectionBadge: FC<BadgeProps> = ({
     it: "Protezione dell’acquirente",
     en: "Buyer Protection",
   }
+
   return (
-    <BaseBadge
-      icon={
-        <div className="text-green-dark">
-          <UmbrellaIcon width="24" height="24" />
-        </div>
-      }
-      tooltipContent={tooltipContent}
-      size={size}
-      text={title[language]}
-    />
+    <div className="text-grey-dark">
+      <BaseBadge
+        icon={
+          <div className="text-green-dark">
+            <UmbrellaIcon width="24" height="24" />
+          </div>
+        }
+        tooltipContent={tooltipContent}
+        size={size}
+        text={title[language]}
+      />
+    </div>
   )
 }
 

--- a/src/components/badges/verified.tsx
+++ b/src/components/badges/verified.tsx
@@ -15,13 +15,16 @@ export const VerifiedBadge: FC<BadgeProps> = ({
     it: "Verificato",
     en: "Verified",
   }
+
   return (
-    <BaseBadge
-      icon={<VerifiedIcon width="24" height="24" />}
-      tooltipContent={tooltipContent}
-      size={size}
-      text={title[language]}
-    />
+    <div className="text-grey-dark">
+      <BaseBadge
+        icon={<VerifiedIcon width="24" height="24" />}
+        tooltipContent={tooltipContent}
+        size={size}
+        text={title[language]}
+      />
+    </div>
   )
 }
 


### PR DESCRIPTION
- fix: Only make the badge having a pointer cursor if there is a tooltip [ref](https://github.com/carforyou/carforyou-listings-web/pull/3246#issuecomment-858561423)
- fix: the colors for the verified and buyer protection badge for use cases like checkboxes in the filters [ref](https://github.com/carforyou/carforyou-listings-web/pull/3246#pullrequestreview-680884580)
- fix: make the bade background white in all uses cases [ref](https://github.com/carforyou/carforyou-listings-web/pull/3246#pullrequestreview-680677726)