### PR TITLE
fix: horizontal scroll on mobile

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -74,11 +74,11 @@ const Modal: FC<ModalProps> = ({
           <CloseMIcon color={style === "dark" ? "#FFFFFF" : "#232A36"} />
         </div>
         <div
-          className={classNames("z-modal w-12/12 my-0 p-15", {
-            "md:p-40 md:w-modalLarge": size === "large",
-            "md:p-40 md:w-modal": size === "medium",
-            "md:p-40 md:w-modalSmall": size === "small",
-            "md:p-0 h-full": size === "fullscreen",
+          className={classNames("z-modal w-12/12 my-0", {
+            "p-15 md:p-40 md:w-modalLarge": size === "large",
+            "p-15 md:p-40 md:w-modal": size === "medium",
+            "p-15 md:p-40 md:w-modalSmall": size === "small",
+            "p-0 h-full": size === "fullscreen",
           })}
         >
           {children({ closeModal: close })}

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -78,7 +78,7 @@ const Modal: FC<ModalProps> = ({
             "p-15 md:p-40 md:w-modalLarge": size === "large",
             "p-15 md:p-40 md:w-modal": size === "medium",
             "p-15 md:p-40 md:w-modalSmall": size === "small",
-            "p-0 h-full": size === "fullscreen",
+            "h-full": size === "fullscreen",
           })}
         >
           {children({ closeModal: close })}


### PR DESCRIPTION
References: https://autoricardo.atlassian.net/browse/CAR-7476

Fixes horizontal scroll on mobile in gallery, and some other modals in DH. 

`fullscreen` modal is used in these places:
**DH:**
- listingsOverviewContent.tsx
- index.tsx (this is my garage)
- printCenterContent.tsx

**Listings**:
- fullScreenSlider.tsx

I've checked all of them. Images below. 
This PR only changes the mobile view for the fullscreen modal.

# Before

Listings gallery:
![image](https://user-images.githubusercontent.com/43354234/121892307-dddda180-cd1c-11eb-942b-0f6674445b26.png)

My garage:
![image](https://user-images.githubusercontent.com/43354234/121892568-3c0a8480-cd1d-11eb-8a56-705c0625b612.png)

listingsOverviewContent and printCenterContent (these filters are pretty much the same):
![image](https://user-images.githubusercontent.com/43354234/121892772-73793100-cd1d-11eb-87b6-639bb8f3ac12.png)


# After 

Listings gallery:
![image](https://user-images.githubusercontent.com/43354234/121892406-ff3e8d80-cd1c-11eb-9e37-2b3751ccbf7f.png)

My garage:
![image](https://user-images.githubusercontent.com/43354234/121892612-49277380-cd1d-11eb-98ce-1f13e80effcc.png)

listingsOverviewContent and printCenterContent (these filters are pretty much the same):
![image](https://user-images.githubusercontent.com/43354234/121892811-7ecc5c80-cd1d-11eb-8fe5-17fa15b6d48d.png)

