### PR TITLE
feat: column segmented control

### DIFF
--- a/src/components/segmentedControl/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/segmentedControl/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SegmentedControl> renders a div tag for a custom renderer with link 1`] = `
 <div
-  class="flex justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-b-2 border-r-2 focus:outline-none bg-transparent text-teal w-12/12 border-teal focus:shadow-focus rounded-none hover:bg-teal-light active:bg-teal-bright"
+  class="flex justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-r-2 focus:outline-none bg-transparent text-teal w-12/12 border-teal focus:shadow-focus border-b-2 rounded-none hover:bg-teal-light active:bg-teal-bright"
 >
   <a
     class="w-12/12 hover:opacity-100 flex flex-col"

--- a/src/components/segmentedControl/button.tsx
+++ b/src/components/segmentedControl/button.tsx
@@ -10,6 +10,7 @@ interface Props {
   small?: boolean
   growing?: boolean
   position: "left" | "right" | "middle"
+  wrapOnSmallScreens?: boolean
   onClick?: () => void
 }
 
@@ -21,6 +22,7 @@ export const Button: FC<Props> = ({
   onClick,
   growing,
   position,
+  wrapOnSmallScreens,
 }) => {
   const padding = classnames("px-8", small ? "py-8" : "py-16")
   const { clonedElement, isWrapped } = wrapLink(children, padding)
@@ -28,21 +30,33 @@ export const Button: FC<Props> = ({
   return createElement(isWrapped ? "div" : "button", {
     ...(!isWrapped ? { type: "button" } : {}),
     className: classnames(
-      "flex justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-b-2 border-r-2 focus:outline-none",
+      "flex justify-center items-center leading-xs transition duration-200 cursor-pointer font-bold text-base border-t-2 border-r-2 focus:outline-none",
       selected ? "bg-teal text-white" : "bg-transparent text-teal",
       growing ? "flex-grow" : "w-12/12",
       disabled
         ? "cursor-not-allowed border-grey-3 bg-grey-1 text-grey-4 hover:border-grey-3 hover:bg-grey-1"
         : "border-teal focus:shadow-focus",
+      wrapOnSmallScreens
+        ? "border-b-0 border-l-2 sm:border-b-2 sm:border-l-0"
+        : "border-b-2",
       {
         [padding]: !isWrapped,
         "rounded-none": position === "middle",
-        "rounded-l border-l-2": position === "left",
-        "rounded-r": position === "right",
         "hover:bg-teal-light active:bg-teal-bright": !selected && !disabled,
         "hover:bg-teal-dark hover:border-teal-dark active:bg-teal-dark active:bg-teal-dark focus:bg-teal-dark focus:border-teal-dark":
           selected && !disabled,
-      }
+      },
+      wrapOnSmallScreens
+        ? {
+            "sm:border-l-2 rounded-t sm:rounded-l sm:rounded-t-none":
+              position === "left",
+            "border-b-2 rounded-b sm:rounded-r sm:rounded-b-none":
+              position === "right",
+          }
+        : {
+            "rounded-l border-l-2": position === "left",
+            "rounded-r": position === "right",
+          }
     ),
     onClick: !disabled ? onClick : null,
     disabled,

--- a/src/components/segmentedControl/index.tsx
+++ b/src/components/segmentedControl/index.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, ReactNode, useState } from "react"
+import classnames from "classnames"
 
 import Button from "./button"
 
@@ -31,6 +32,7 @@ interface Props<T> {
   small?: boolean
   disabled?: boolean
   growing?: boolean
+  wrapOnSmallScreens?: boolean
 }
 
 function SegmentedControl<T>({
@@ -41,6 +43,7 @@ function SegmentedControl<T>({
   small = false,
   disabled = false,
   growing = false,
+  wrapOnSmallScreens = false,
 }: Props<T>): ReactElement {
   const [selectedValue, updateSelected] = useState(
     (options.find(({ value }) => value === initialSelection) || options[0])
@@ -49,7 +52,12 @@ function SegmentedControl<T>({
   const lastOption = options.length - 1
 
   return (
-    <div className="flex w-12/12">
+    <div
+      className={classnames(
+        "flex w-12/12",
+        wrapOnSmallScreens && "flex-col sm:flex-row"
+      )}
+    >
       {options.map(({ name, value }, index) => {
         const selected = value === selectedValue
         return (
@@ -59,6 +67,7 @@ function SegmentedControl<T>({
             disabled={disabled}
             small={small}
             growing={growing}
+            wrapOnSmallScreens={wrapOnSmallScreens}
             position={
               index === 0 ? "left" : index === lastOption ? "right" : "middle"
             }

--- a/src/stories/segmentedControl.stories.tsx
+++ b/src/stories/segmentedControl.stories.tsx
@@ -19,6 +19,7 @@ const initialSelection = (initial = null) => initial
 const small = (initial = false) => initial
 const disabled = (initial = false) => initial
 const growing = (initial = false) => initial
+const wrapOnSmallScreens = (initial = false) => initial
 
 export default {
   title: "Segmented Control",
@@ -55,6 +56,7 @@ Default.args = {
   small: small(),
   disabled: disabled(),
   growing: growing(),
+  wrapOnSmallScreens: wrapOnSmallScreens(),
 }
 
 export const WithTwoButtons = Template.bind({})
@@ -68,6 +70,7 @@ WithTwoButtons.args = {
   initialSelection: initialSelection(),
   small: small(),
   disabled: disabled(),
+  wrapOnSmallScreens: wrapOnSmallScreens(),
 }
 
 export const WithoutSelectionHandler = Template.bind({})
@@ -77,6 +80,7 @@ WithoutSelectionHandler.args = {
   initialSelection: initialSelection(2),
   small: small(),
   disabled: disabled(),
+  wrapOnSmallScreens: wrapOnSmallScreens(),
 }
 
 export const WithInitialSelection = Template.bind({})
@@ -87,6 +91,7 @@ WithInitialSelection.args = {
   initialSelection: initialSelection(2),
   small: small(),
   disabled: disabled(),
+  wrapOnSmallScreens: wrapOnSmallScreens(),
 }
 
 export const WithCustomOptionRender = Template.bind({})
@@ -97,6 +102,7 @@ WithCustomOptionRender.args = {
   initialSelection: initialSelection(),
   small: small(),
   disabled: disabled(),
+  wrapOnSmallScreens: wrapOnSmallScreens(),
   renderOption: ({ name, value }) => (
     <div className="w-12/12 flex justify-between">
       <span>{name}</span>
@@ -113,6 +119,7 @@ Small.args = {
   initialSelection: initialSelection(),
   small: small(true),
   disabled: disabled(),
+  wrapOnSmallScreens: wrapOnSmallScreens(),
 }
 
 export const Disabled = Template.bind({})
@@ -123,6 +130,7 @@ Disabled.args = {
   initialSelection: initialSelection(),
   small: small(),
   disabled: disabled(true),
+  wrapOnSmallScreens: wrapOnSmallScreens(),
 }
 
 export const DisabledSmall = Template.bind({})
@@ -133,6 +141,7 @@ DisabledSmall.args = {
   initialSelection: initialSelection(),
   small: small(true),
   disabled: disabled(true),
+  wrapOnSmallScreens: wrapOnSmallScreens(),
 }
 
 export const Growing = Template.bind({})
@@ -148,4 +157,17 @@ Growing.args = {
   small: small(true),
   disabled: disabled(),
   growing: growing(true),
+  wrapOnSmallScreens: wrapOnSmallScreens(),
+}
+
+export const WrapOnSmallScreens = Template.bind({})
+WrapOnSmallScreens.args = {
+  storyName: "Wraps on small screens",
+  options: options(),
+  onSelect: onSelect(),
+  initialSelection: initialSelection(),
+  small: small(),
+  disabled: disabled(),
+  growing: growing(),
+  wrapOnSmallScreens: wrapOnSmallScreens(true),
 }


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/CAR-7787

Adds a segmented control that wraps to a column on `sm` resolutions. When there are >2 options with long texts, the basic segmented control tends to overflow horizontally on smaller screens.

related to: https://github.com/carforyou/carforyou-dealerhub-web/pull/1369