### PR TITLE
CAR-7019: use callback for open and close modal to prevent rerenders

### DIFF
--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom"
-import React, { RefObject, useEffect, useState } from "react"
+import React, { RefObject, useCallback, useEffect, useState } from "react"
 
 import classNames from "classnames"
 
@@ -32,13 +32,13 @@ const useModal = (
     onClose = null,
   } = options || {}
 
-  const openModal = () => {
+  const openModal = useCallback(() => {
     setVisible(true)
-  }
+  }, [])
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setVisible(false)
-  }
+  }, [])
 
   useEffect(() => {
     if (isVisible) {


### PR DESCRIPTION
open and close modal triggered a rerender of the whole parent component everytime they were called. 

Related PR: https://github.com/carforyou/carforyou-listings-web/pull/3341