### PR TITLE
CAR-8045: new style "white" for button

### DIFF
--- a/src/components/__tests__/__snapshots__/button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/button.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Button> button variations renders disabled button 1`] = `
     class="flex flex-col"
   >
     <button
-      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-52 rounded border bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon cursor-not-allowed  bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4"
+      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-52 rounded border bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4 cursor-not-allowed"
       disabled=""
       type="button"
     >
@@ -37,7 +37,7 @@ exports[`<Button> button variations renders small disabled button 1`] = `
     class="flex flex-col"
   >
     <button
-      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-36 rounded border bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon cursor-not-allowed  bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4"
+      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-36 rounded border bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4 cursor-not-allowed"
       disabled=""
       type="button"
     >

--- a/src/components/__tests__/__snapshots__/button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/button.test.tsx.snap
@@ -107,6 +107,37 @@ exports[`<Button> button variations renders white Teal small button 1`] = `
 </div>
 `;
 
+exports[`<Button> button variations renders white-border button 1`] = `
+<div>
+  <div
+    class="flex flex-col"
+  >
+    <button
+      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-52 rounded border bg-none text-white hover:opacity-60 border-white"
+      type="button"
+    >
+      Label
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Button> button variations renders white-border disabled button 1`] = `
+<div>
+  <div
+    class="flex flex-col"
+  >
+    <button
+      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-52 rounded border bg-none text-white hover:opacity-60 border-white text-grey-3 border-grey-3 hover:opacity-100 cursor-not-allowed"
+      disabled=""
+      type="button"
+    >
+      Label
+    </button>
+  </div>
+</div>
+`;
+
 exports[`<Button> renders a div with link as a child 1`] = `
 <div
   class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none"

--- a/src/components/__tests__/__snapshots__/button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/button.test.tsx.snap
@@ -16,6 +16,22 @@ exports[`<Button> button variations renders disabled button 1`] = `
 </div>
 `;
 
+exports[`<Button> button variations renders disabled white-border button 1`] = `
+<div>
+  <div
+    class="flex flex-col"
+  >
+    <button
+      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-52 rounded border bg-none text-white hover:opacity-60 border-white text-grey-3 border-grey-3 hover:opacity-100 cursor-not-allowed"
+      disabled=""
+      type="button"
+    >
+      Label
+    </button>
+  </div>
+</div>
+`;
+
 exports[`<Button> button variations renders small button 1`] = `
 <div>
   <div
@@ -114,22 +130,6 @@ exports[`<Button> button variations renders white-border button 1`] = `
   >
     <button
       class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-52 rounded border bg-none text-white hover:opacity-60 border-white"
-      type="button"
-    >
-      Label
-    </button>
-  </div>
-</div>
-`;
-
-exports[`<Button> button variations renders white-border disabled button 1`] = `
-<div>
-  <div
-    class="flex flex-col"
-  >
-    <button
-      class="flex w-12/12 justify-center items-center text-center text-white leading-xs transition duration-200 cursor-pointer font-bold text-base focus:outline-none px-10 min-h-52 rounded border bg-none text-white hover:opacity-60 border-white text-grey-3 border-grey-3 hover:opacity-100 cursor-not-allowed"
-      disabled=""
       type="button"
     >
       Label

--- a/src/components/__tests__/button.test.tsx
+++ b/src/components/__tests__/button.test.tsx
@@ -72,6 +72,20 @@ describe("<Button>", () => {
       )
       expect(container).toMatchSnapshot()
     })
+
+    it("renders white-border button", () => {
+      const { container } = render(<Button style="white-border">Label</Button>)
+      expect(container).toMatchSnapshot()
+    })
+
+    it("renders white-border disabled button", () => {
+      const { container } = render(
+        <Button style="white-border" disabled={true}>
+          Label
+        </Button>
+      )
+      expect(container).toMatchSnapshot()
+    })
   })
 
   it("has correct padding without the custom renderer", () => {

--- a/src/components/__tests__/button.test.tsx
+++ b/src/components/__tests__/button.test.tsx
@@ -78,7 +78,7 @@ describe("<Button>", () => {
       expect(container).toMatchSnapshot()
     })
 
-    it("renders white-border disabled button", () => {
+    it("renders disabled white-border button", () => {
       const { container } = render(
         <Button style="white-border" disabled={true}>
           Label

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -7,7 +7,7 @@ interface Props {
   /** - */
   children: ReactNode
   dataTestid?: string
-  style?: "salmon" | "teal" | "teal-border"
+  style?: "salmon" | "teal" | "teal-border" | "white"
   size?: "large" | "small" | "responsive"
   disabled?: boolean
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void
@@ -37,17 +37,29 @@ export const Button: FC<Props> = ({
     "min-h-52": size === "large",
     "min-h-36 lg:min-h-52": size === "responsive",
   })
-  const classes = classnames("rounded border", {
-    "bg-teal hover:bg-teal-dark focus:bg-teal border-teal": style === "teal",
-    "bg-white text-teal hover:opacity-60 border-teal": style === "teal-border",
-    "bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon":
-      style === "salmon",
-    "cursor-not-allowed ": disabled,
-    "bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4":
-      disabled && style !== "teal-border",
-    "text-grey-3 border-grey-3 hover:opacity-100":
-      disabled && style === "teal-border",
-  })
+
+  const buttonStyles = {
+    teal: "bg-teal hover:bg-teal-dark focus:bg-teal border-teal",
+    "teal-border": "bg-white text-teal hover:opacity-60 border-teal",
+    white: "bg-none text-white hover:opacity-60 border-white",
+    salmon: "bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon",
+  }
+
+  const disabledStyles = {
+    teal: "bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4",
+    "teal-border": "text-grey-3 border-grey-3 hover:opacity-100",
+    white: "text-grey-3 border-grey-3 hover:opacity-100",
+    salmon: "bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4",
+  }
+
+  const classes = classnames(
+    "rounded border",
+    buttonStyles[style],
+    disabled && disabledStyles[style],
+    {
+      "cursor-not-allowed": disabled,
+    }
+  )
   const buttonClasses = classnames(padding, classes)
 
   const { clonedElement, isWrapped } = wrapLink(

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -7,7 +7,7 @@ interface Props {
   /** - */
   children: ReactNode
   dataTestid?: string
-  style?: "salmon" | "teal" | "teal-border" | "white"
+  style?: "salmon" | "teal" | "teal-border" | "white-border"
   size?: "large" | "small" | "responsive"
   disabled?: boolean
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void
@@ -41,14 +41,14 @@ export const Button: FC<Props> = ({
   const buttonStyles = {
     teal: "bg-teal hover:bg-teal-dark focus:bg-teal border-teal",
     "teal-border": "bg-white text-teal hover:opacity-60 border-teal",
-    white: "bg-none text-white hover:opacity-60 border-white",
+    "white-border": "bg-none text-white hover:opacity-60 border-white",
     salmon: "bg-salmon border-salmon hover:bg-salmon-dark focus:bg-salmon",
   }
 
   const disabledStyles = {
     teal: "bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4",
     "teal-border": "text-grey-3 border-grey-3 hover:opacity-100",
-    white: "text-grey-3 border-grey-3 hover:opacity-100",
+    "white-border": "text-grey-3 border-grey-3 hover:opacity-100",
     salmon: "bg-grey-1 border-grey-1 hover:bg-grey-1 text-grey-4",
   }
 

--- a/src/stories/button.stories.tsx
+++ b/src/stories/button.stories.tsx
@@ -30,6 +30,7 @@ const Template: FC<Props> = (args) => {
     <StoryContainer
       title={args.storyName}
       component={<Button {...args}>{args.label}</Button>}
+      style={args.style === "white" ? "bg-grey-dark p-20" : ""}
     />
   )
 }
@@ -81,6 +82,19 @@ TealBorderDisabled.args = {
   style: "teal-border",
   disabled: true,
   storyName: "Teal Border",
+}
+
+export const White = Template.bind({})
+White.args = {
+  style: "white",
+  storyName: "White",
+}
+
+export const WhiteDisabled = Template.bind({})
+WhiteDisabled.args = {
+  style: "white",
+  disabled: true,
+  storyName: "White",
 }
 
 export const WrappingALink = Template.bind({})

--- a/src/stories/button.stories.tsx
+++ b/src/stories/button.stories.tsx
@@ -30,7 +30,7 @@ const Template: FC<Props> = (args) => {
     <StoryContainer
       title={args.storyName}
       component={<Button {...args}>{args.label}</Button>}
-      style={args.style === "white" ? "bg-grey-dark p-20" : ""}
+      style={args.style === "white-border" ? "bg-grey-dark p-20" : ""}
     />
   )
 }
@@ -86,15 +86,15 @@ TealBorderDisabled.args = {
 
 export const White = Template.bind({})
 White.args = {
-  style: "white",
-  storyName: "White",
+  style: "white-border",
+  storyName: "White border",
 }
 
 export const WhiteDisabled = Template.bind({})
 WhiteDisabled.args = {
-  style: "white",
+  style: "white-border",
   disabled: true,
-  storyName: "White",
+  storyName: "White border disabled",
 }
 
 export const WrappingALink = Template.bind({})


### PR DESCRIPTION
Reference: [CAR-8045](https://autoricardo.atlassian.net/browse/CAR-8045)

For the new make page, we need a white button:
![image](https://user-images.githubusercontent.com/71456764/126275901-f34840fc-aed0-4861-8459-79379a71257a.png)

I refactored the styles a bit and went for more duplication. It was no longer readable when adding another style
