### PR TITLE
fix: padding in gallery modal

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -85,10 +85,10 @@ const Modal: FC<ModalProps> = ({
         role="dialog"
       >
         <div
-          className={classNames("z-modal w-12/12 my-0 p-15 md:p-40", {
-            "md:w-modalLarge": size === "large",
-            "md:w-modal": size === "medium",
-            "md:w-modalSmall": size === "small",
+          className={classNames("z-modal w-12/12 my-0", {
+            "p-15 md:p-40 md:w-modalLarge": size === "large",
+            "p-15 md:p-40 md:w-modal": size === "medium",
+            "p-15 md:p-40 md:w-modalSmall": size === "small",
             "h-full": size === "fullscreen",
           })}
         >


### PR DESCRIPTION
Accidentally I have moved the paddings for all the sizes but the fullscreen shouldn't have those paddings. Otherwise, it will be padding in the gallery modal in listings on the PDP and as a result a horizontal scrollbar.

# Thank you 🔪