### PR TITLE
fix: handle null gbdScore gracefully

### DIFF
--- a/src/components/badges/__tests__/gdbd.test.tsx
+++ b/src/components/badges/__tests__/gdbd.test.tsx
@@ -34,7 +34,7 @@ describe("<GdbdBadge>", () => {
       expect(getByText("Above market price"))
     })
 
-    it("renders the badge fon not defined", () => {
+    it("renders the badge for not defined", () => {
       const { getByText } = render(
         <GdbdBadge language="en" score="not-defined" />
       )

--- a/src/components/badges/__tests__/gdbd.test.tsx
+++ b/src/components/badges/__tests__/gdbd.test.tsx
@@ -34,10 +34,15 @@ describe("<GdbdBadge>", () => {
       expect(getByText("Above market price"))
     })
 
-    it("renders the badge without a score", () => {
+    it("renders the badge fon not defined", () => {
       const { getByText } = render(
         <GdbdBadge language="en" score="not-defined" />
       )
+      expect(getByText("No price check"))
+    })
+
+    it("renders the badge without a score", () => {
+      const { getByText } = render(<GdbdBadge language="en" score={null} />)
       expect(getByText("No price check"))
     })
   })
@@ -71,10 +76,15 @@ describe("<GdbdBadge>", () => {
       expect(getByText("Über dem Marktpreis"))
     })
 
-    it("renders the badge without a score", () => {
+    it("renders the badge for not defined", () => {
       const { getByText } = render(
         <GdbdBadge language="de" score="not-defined" />
       )
+      expect(getByText("Kein Preischeck"))
+    })
+
+    it("renders the badge without a score", () => {
+      const { getByText } = render(<GdbdBadge language="de" score={null} />)
       expect(getByText("Kein Preischeck"))
     })
   })
@@ -108,10 +118,15 @@ describe("<GdbdBadge>", () => {
       expect(getByText("Au-dessus du marché"))
     })
 
-    it("renders the badge without a score", () => {
+    it("renders the badge for not defined", () => {
       const { getByText } = render(
         <GdbdBadge language="fr" score="not-defined" />
       )
+      expect(getByText("Prix non comparable"))
+    })
+
+    it("renders the badge without a score", () => {
+      const { getByText } = render(<GdbdBadge language="fr" score={null} />)
       expect(getByText("Prix non comparable"))
     })
   })
@@ -145,10 +160,15 @@ describe("<GdbdBadge>", () => {
       expect(getByText("Sopra valore di mercato"))
     })
 
-    it("renders the badge without a score", () => {
+    it("renders the badge for not defined", () => {
       const { getByText } = render(
         <GdbdBadge language="it" score="not-defined" />
       )
+      expect(getByText("Prezzo non comparabile"))
+    })
+
+    it("renders the badge without a score", () => {
+      const { getByText } = render(<GdbdBadge language="it" score={null} />)
       expect(getByText("Prezzo non comparabile"))
     })
   })

--- a/src/components/badges/gdbd.tsx
+++ b/src/components/badges/gdbd.tsx
@@ -18,10 +18,11 @@ interface GdbdBadgeProps extends BadgeProps {
 
 export const GdbdBadge: FC<GdbdBadgeProps> = ({
   language,
-  score = "not-defined",
+  score,
   tooltipContent,
   size = "large",
 }) => {
+  const scoreOrDefault = score || "not-defined"
   const title = {
     de: {
       "fair-deal": "Marktpreis",
@@ -52,10 +53,10 @@ export const GdbdBadge: FC<GdbdBadgeProps> = ({
       "not-defined": "Prezzo non comparabile",
     },
   }
-  const text = title[language][score]
+  const text = title[language][scoreOrDefault]
 
   return (
-    <div className={styles[score]}>
+    <div className={styles[scoreOrDefault]}>
       <BaseBadge
         icon={<PriceCheckIcon width="24" height="24" />}
         tooltipContent={tooltipContent}


### PR DESCRIPTION
Due to changes in the calculation of `gdbScore`, there is no default anymore. That means `null` can be sent when the calculation is not yet finished on the BE side. We've been asked to handle `nulls` the same way as `not-defined` in the frontend since it's not feasible to set the default value on elasticsearch.

###  Before
```
<GdbBadge score={null} />
```
Would render a black, unstyled label without text

### After
```
<GdbBadge score={null} />
```
looks the same as
```
<GdbBadge score={"not-defined"} />
```