### PR TITLE
feat: add onSelect to range filter & onApply to input filter

### DIFF
--- a/src/components/__tests__/rangeSelect.test.tsx
+++ b/src/components/__tests__/rangeSelect.test.tsx
@@ -2,9 +2,11 @@ import React from "react"
 import { fireEvent, render } from "@testing-library/react"
 
 import RangeSelect from "../rangeSelect"
+import { act } from "react-test-renderer"
 
 const onChangeMin = jest.fn()
 const onChangeMax = jest.fn()
+const onSelect = jest.fn()
 
 const renderWrapper = ({
   minName = "nameFrom",
@@ -23,6 +25,7 @@ const renderWrapper = ({
     { name: "5", value: 5 },
     { name: "6", value: 6 },
   ],
+  handleSelect = onSelect,
 } = {}) =>
   render(
     <RangeSelect
@@ -43,6 +46,7 @@ const renderWrapper = ({
         max: handleChangeMax,
       }}
       options={options}
+      onSelect={handleSelect}
     />
   )
 
@@ -67,5 +71,22 @@ describe("RangeSelect", () => {
     ) as HTMLInputElement
     fireEvent.click(input)
     expect(getByText("1"))
+  })
+
+  it("fires the onSelect event with the correct name and value", () => {
+    const mockedOnSelect = jest.fn()
+    const { getByPlaceholderText, getByText } = renderWrapper({
+      handleSelect: mockedOnSelect,
+    })
+
+    const input = getByPlaceholderText("min")
+
+    act(() => {
+      fireEvent.click(input)
+      const option = getByText("1")
+      fireEvent.click(option)
+    })
+
+    expect(mockedOnSelect).toHaveBeenCalledWith({ name: "nameFrom", value: 1 })
   })
 })

--- a/src/components/__tests__/rangeSelect.test.tsx
+++ b/src/components/__tests__/rangeSelect.test.tsx
@@ -1,8 +1,8 @@
+import { act } from "react-test-renderer"
 import React from "react"
 import { fireEvent, render } from "@testing-library/react"
 
 import RangeSelect from "../rangeSelect"
-import { act } from "react-test-renderer"
 
 const onChangeMin = jest.fn()
 const onChangeMax = jest.fn()

--- a/src/components/filters/input.tsx
+++ b/src/components/filters/input.tsx
@@ -15,6 +15,7 @@ interface Props {
   max?: number
   position?: "left" | "right"
   apply: (event) => void
+  onApply?: (value: string) => void
 }
 
 const InputFilter: FC<Props> = ({
@@ -27,6 +28,7 @@ const InputFilter: FC<Props> = ({
   max,
   position,
   apply,
+  onApply,
 }) => {
   const [refocus, setRefocus] = useState(false)
   const inputRef = useRef()
@@ -47,17 +49,22 @@ const InputFilter: FC<Props> = ({
     })
   }
 
-  const onChange = (event) => apply(event)
+  const applyWithTrigger = (event) => {
+    apply(event)
+    onApply && onApply(event.target.value)
+  }
+
+  const onChange = (event) => applyWithTrigger(event)
 
   const onKeyDown = (event) => {
     if (event.keyCode === 13) {
       event.preventDefault()
-      apply(event)
+      applyWithTrigger(event)
     }
   }
 
   const onBlur = (event) => {
-    apply(event)
+    applyWithTrigger(event)
     setRefocus(false)
   }
 

--- a/src/components/rangeSelect.tsx
+++ b/src/components/rangeSelect.tsx
@@ -8,8 +8,8 @@ interface Props {
     max: string
   }
   handleChange: {
-    min: (value) => void
-    max: (value) => void
+    min: (value: number) => void
+    max: (value: number) => void
   }
   value?: {
     min: number
@@ -20,6 +20,7 @@ interface Props {
     max: string
   }
   options?: Array<{ name: string; value: number }>
+  onSelect?: (data: { name: string; value: number }) => void
 }
 
 const RangeSelect: FC<Props> = ({
@@ -28,6 +29,7 @@ const RangeSelect: FC<Props> = ({
   value: { min: minValue = null, max: maxValue = null } = {},
   placeholder: { min: minPlaceholder = "", max: maxPlaceholder = "" },
   options,
+  onSelect,
 }) => {
   return (
     <div className="relative inline-flex">
@@ -37,7 +39,10 @@ const RangeSelect: FC<Props> = ({
           placeholder={minPlaceholder}
           options={options}
           selected={minValue ? Number(minValue) : null}
-          handleChange={handleChangeMin}
+          handleChange={(value) => {
+            handleChangeMin(value)
+            onSelect && onSelect({ name: minName, value })
+          }}
           position="left"
           inputMode="numeric"
           withAutosuggest
@@ -50,7 +55,10 @@ const RangeSelect: FC<Props> = ({
           placeholder={maxPlaceholder}
           options={options}
           selected={maxValue ? Number(maxValue) : null}
-          handleChange={handleChangeMax}
+          handleChange={(value) => {
+            handleChangeMax(value)
+            onSelect && onSelect({ name: maxName, value })
+          }}
           position="right"
           inputMode="numeric"
           withAutosuggest


### PR DESCRIPTION
References CAR-8280

When we extracted range selects from listings we did not consider tracking in any way (probably because those filters weren't tracked). With new requirements and more and more filters being implemented it makes sense to support that.
I deliberately chose a separate prop to distinguish between applying the filter (change handler) and tracking (or doing something else with the selected value). This is consistent with the behaviour we have in the checkbox filter.

Same principle is followed with `onApply` prop for input filter that was also left out before
