### PR TITLE
fix: logout behavior based on what we actually pass in the app

### DIFF
--- a/src/components/intercom/index.tsx
+++ b/src/components/intercom/index.tsx
@@ -120,7 +120,7 @@ export const Intercom: FC<Props> = ({
     }
   }, [userInfo])
 
-  const isLoggedIn = userInfo.user_id && userInfo.email
+  const isLoggedIn = !!userInfo.user_id
 
   useDeepCompareEffect(() => {
     if (!isLoggedIn && window.Intercom) {


### PR DESCRIPTION
We never passed the `email` to Intercom, only the `userId`. Even if we ever passed the email, this is enough to detect a logged-in user.

## Before
Log into DH and log out again, Intercom retains the logged in state:
<img width="403" alt="Screenshot 2021-08-13 at 11 41 12" src="https://user-images.githubusercontent.com/2797/129338290-0992822e-e910-4136-b436-558fab7c303f.png">


## After
Log into DH and log out again, Intercom properly forgets the user and asks for contact details:
<img width="399" alt="Screenshot 2021-08-13 at 11 41 25" src="https://user-images.githubusercontent.com/2797/129338282-91302bf1-6781-4252-bf4e-39b6e65b1ecd.png">
