### PR TITLE
feat: do not rely on input being required to display the floating label

### DIFF
--- a/assets/input/floatingLabel.css
+++ b/assets/input/floatingLabel.css
@@ -8,17 +8,18 @@ input.floatingLabel-input:focus {
 }
 
 input.floatingLabel-input:focus ~ .floatingLabel-label {
-  @apply text-teal
+  @apply text-teal;
 }
 
 .floatingLabel-input[data-valid="false"] ~ .floatingLabel-label,
 .floatingLabel-input[data-valid="false"]:focus ~ .floatingLabel-label {
-  @apply text-salmon
+  @apply text-salmon;
 }
 
 .floatingLabel-input:focus ~ .floatingLabel-label,
 .floatingLabel-input:disabled ~ .floatingLabel-label,
-.floatingLabel-input:valid ~ .floatingLabel-label {
+.floatingLabel-input:required:valid ~ .floatingLabel-label,
+.floatingLabel-input:optional:not(:placeholder-shown) ~ .floatingLabel-label {
   @apply text-xs -top-floatingLabel;
 }
 
@@ -26,12 +27,24 @@ input.floatingLabel-input:focus ~ .floatingLabel-label {
   top: 16px;
 }
 
-.clearButton-container > .floatingLabel > .floatingLabel-input:valid ~ .floatingLabel-label,
-.clearButton-container > .floatingLabel > .floatingLabel-input:disabled ~ .floatingLabel-label,
-.clearButton-container > .floatingLabel > .floatingLabel-input:focus ~ .floatingLabel-label {
+.clearButton-container
+  > .floatingLabel
+  > .floatingLabel-input:required:valid
+  ~ .floatingLabel-label,
+.clearButton-container
+  > .floatingLabel
+  > .floatingLabel-input:optional:not(:placeholder-shown)
+  ~ .floatingLabel-label,
+.clearButton-container
+  > .floatingLabel
+  > .floatingLabel-input:disabled
+  ~ .floatingLabel-label,
+.clearButton-container
+  > .floatingLabel
+  > .floatingLabel-input:focus
+  ~ .floatingLabel-label {
   top: 3px;
 }
-
 
 input::-webkit-input-placeholder {
   opacity: 1;

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -92,8 +92,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
     ref
   ) => {
     const inputRef = useRef()
-    const required =
-      "floatingLabel" in rest || ("required" in rest ? rest.required : null)
+    const required = "required" in rest ? rest.required : null
     const labelProps =
       "floatingLabel" in rest
         ? { floating: rest.floatingLabel }
@@ -139,7 +138,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
         ref={inputRef}
         name={name}
         value={value || ""}
-        placeholder={placeholder || ""}
+        placeholder={placeholder || " "} // safari needs a non empty placeholder to make the :placeholder-shown pseudo selector work
         className={classNames("w-12/12", {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           input_withClearButton: hasClearButton,


### PR DESCRIPTION
Ref: https://autoricardo.atlassian.net/browse/CAR-8253

For the migrated buyer protection form we wanna use the HTML validation in the first version.
The floating label input makes every input required which prevents us from doing so.
Instead of using the `:valid` pseudo selector use the `:placeholder-shown` to make the label floating

Testing:

Check out the branch and ensure the floating labels are working the same as before