### PR TITLE
fix(intercom): size the chat icon

### DIFF
--- a/src/components/fieldHelpers/withClearButton.tsx
+++ b/src/components/fieldHelpers/withClearButton.tsx
@@ -29,7 +29,7 @@ const WithClearButton: FC<Props> = ({
           onClick={!disabled ? onClear : null}
         >
           <div className="items-center justify-center flex h-full w-full">
-            <CloseSIcon />
+            <CloseSIcon width="24" height="24" />
           </div>
         </div>
       ) : null}

--- a/src/components/intercom/index.tsx
+++ b/src/components/intercom/index.tsx
@@ -50,7 +50,7 @@ const renderLauncher = (state: State, label) => {
     case "Ready":
       return (
         <div className="flex items-center">
-          <ChatIcon width="32" heigh="32" />
+          <ChatIcon width="32" height="32" />
           {label}
         </div>
       )
@@ -69,7 +69,7 @@ const renderLauncher = (state: State, label) => {
           className="w-12/12 h-full flex items-center justify-center"
           data-testid="intercom-close"
         >
-          <CloseIcon />
+          <CloseIcon width="32" height="32" />
         </div>
       )
     }

--- a/src/components/intercom/index.tsx
+++ b/src/components/intercom/index.tsx
@@ -50,7 +50,7 @@ const renderLauncher = (state: State, label) => {
     case "Ready":
       return (
         <div className="flex items-center">
-          <ChatIcon />
+          <ChatIcon width="32" heigh="32" />
           {label}
         </div>
       )


### PR DESCRIPTION
The size gets stripped with the new asset setup. Checked the other components they looked fine, most of them already define custom width height when consuming the icons.

Before

![Screenshot 2021-09-09 at 07 21 51](https://user-images.githubusercontent.com/3371760/132628404-fb8ac73b-f446-4313-9445-e5258d2a6557.png)
![Screenshot 2021-09-09 at 07 19 28](https://user-images.githubusercontent.com/3371760/132628406-e75b3533-1efa-4a3e-a2db-5c06e67e4069.png)


After

![image](https://user-images.githubusercontent.com/3371760/132628388-21f29237-a431-4830-9960-b1a1ac3261ef.png)

