### PR TITLE
fix: add sizes to arrow icon on preview card

### DIFF
--- a/src/components/previewCard/index.tsx
+++ b/src/components/previewCard/index.tsx
@@ -63,7 +63,11 @@ const PreviewCard: FC<Props> = ({
           className="text-teal flex items-center font-bold mt-16"
         >
           {previewLabel}
-          <ArrowIcon className="text-teal transform customRotate-270" />
+          <ArrowIcon
+            width={32}
+            height={32}
+            className="text-teal transform customRotate-270"
+          />
         </a>
         <hr className="text-grey-1 my-20" />
         <div className="w-12/12 flex items-center">


### PR DESCRIPTION
References: https://autoricardo.atlassian.net/browse/CAR-8519

## before
<img width="459" alt="Screenshot 2021-09-10 at 16 14 03" src="https://user-images.githubusercontent.com/144707/132868082-55cb8019-c16a-48fd-bd5d-ccd0eefd4834.png">

## After
<img width="447" alt="Screenshot 2021-09-10 at 16 19 13" src="https://user-images.githubusercontent.com/144707/132868141-653d4ce3-b6a2-422f-a9d2-537dbf1d01f1.png">
