### PR TITLE
fix: info icon size for label popup

### DIFF
--- a/src/components/fieldHelpers/withLabel.tsx
+++ b/src/components/fieldHelpers/withLabel.tsx
@@ -46,7 +46,7 @@ const WithLabel: FC<Props> = ({
                 openModal()
               }}
             >
-              <InfoIcon />
+              <InfoIcon width="24" height="24" />
             </a>
           )}
         </b>


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/CAR-8536

Icon was way too big. size got lost with #406 