### PR TITLE
feat: allow to load image lazy for preview card

### DIFF
--- a/src/components/previewCard/index.tsx
+++ b/src/components/previewCard/index.tsx
@@ -11,6 +11,7 @@ interface Props {
   cardTitle?: string
   previewLabel: string
   image?: string
+  loading?: "lazy" | "eager"
   logo?: string
   link?: string
   onImageFailedLoading?: (e) => void
@@ -22,6 +23,7 @@ const PreviewCard: FC<Props> = ({
   cardTitle,
   previewLabel,
   image,
+  loading = "eager",
   logo,
   link,
   onImageFailedLoading,
@@ -40,6 +42,7 @@ const PreviewCard: FC<Props> = ({
               onError={(e) => {
                 onImageFailedLoading && onImageFailedLoading(e)
               }}
+              loading={loading}
             />
           )}
         </div>
@@ -73,7 +76,12 @@ const PreviewCard: FC<Props> = ({
         <div className="w-12/12 flex items-center">
           {logo ? (
             <div className="w-2/12 mr-10">
-              <img src={logo} alt={"logo"} className={"flex-shrink-0 mr-10"} />
+              <img
+                src={logo}
+                alt={"logo"}
+                className={"flex-shrink-0 mr-10"}
+                loading={loading}
+              />
             </div>
           ) : null}
           <div className="w-10/12">

--- a/src/components/previewCard/index.tsx
+++ b/src/components/previewCard/index.tsx
@@ -11,7 +11,7 @@ interface Props {
   cardTitle?: string
   previewLabel: string
   image?: string
-  loading?: "lazy" | "eager"
+  imageLoading?: "lazy" | "eager"
   logo?: string
   link?: string
   onImageFailedLoading?: (e) => void
@@ -23,7 +23,7 @@ const PreviewCard: FC<Props> = ({
   cardTitle,
   previewLabel,
   image,
-  loading = "eager",
+  imageLoading = "eager",
   logo,
   link,
   onImageFailedLoading,
@@ -42,7 +42,7 @@ const PreviewCard: FC<Props> = ({
               onError={(e) => {
                 onImageFailedLoading && onImageFailedLoading(e)
               }}
-              loading={loading}
+              loading={imageLoading}
             />
           )}
         </div>
@@ -80,7 +80,7 @@ const PreviewCard: FC<Props> = ({
                 src={logo}
                 alt={"logo"}
                 className={"flex-shrink-0 mr-10"}
-                loading={loading}
+                loading={imageLoading}
               />
             </div>
           ) : null}


### PR DESCRIPTION
Modern browsers support built-in lazy loading for images. It does not break anything in older browsers, it will be just ignored. This adds the ability for this to PreviewCard which is used for garage promotion on the HP