### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,28 @@
 {
-  "extends": ["config:base", ":preserveSemverRanges"],
-  "prConcurrentLimit": 5,
+  "extends": [
+    "config:base",
+    "schedule:earlyMondays",
+    ":pinOnlyDevDependencies"
+  ],
   "reviewers": ["team:frontend"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "matchDatasources": ["docker", "final"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "schedule": null,
+      "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["^@carforyou\/.*"],
+      "schedule": null,
+      "automerge": false
+    }
+  ],
   "node": {
     "supportPolicy": ["lts_latest"]
   }


### PR DESCRIPTION
References https://github.com/carforyou/carforyou-docs/issues/100

## Motivation and context

first baby steps towards pinning and automerging in packages to test the config

it relies heavily on the base config, but:
- schedules weekly
- timely updates for important updates and internal packages
- automerge dev dependencies
- automerge node updates
- pin dev dependencies only as described in best practices

Apart from node updates, most noise comes from @carforyou/components and @carforyou/api-client. I believe these two are very specific dependencies that will have a very specific way of handling them, maybe even depending on the project. I'll tackle them separately

Packages will also have different handling. I first want to see the mechanics in one project before we move on to other ptojects.

After this, we will have a lot of PRs incoming for pinning the dependencies when I understand correctly

## Before

Nothing is automerged

## After

node updates, dev dependencies are automerged when the tests pass. we always get a PR for it

