### PR TITLE
fix: distingush between null and empty facets

### DIFF
--- a/src/components/filters/__tests__/checkbox.test.tsx
+++ b/src/components/filters/__tests__/checkbox.test.tsx
@@ -13,7 +13,7 @@ const renderWrapper = ({
   ],
   applyFilters = jest.fn(),
   selected = [],
-  facet = {},
+  facet = null,
   children = null,
   onSelect = jest.fn(),
 } = {}) => {
@@ -123,6 +123,16 @@ describe("<CheckboxFilter/>", () => {
       facet: { "1": 30, "2": 1000 },
     })
 
+    expect(getByLabelText("Three", { exact: false })).toHaveProperty("disabled")
+  })
+
+  it("disables non-selected options when facet is provided and empty", () => {
+    const { getByLabelText } = renderWrapper({
+      facet: {},
+    })
+
+    expect(getByLabelText("One", { exact: false })).toHaveProperty("disabled")
+    expect(getByLabelText("Two", { exact: false })).toHaveProperty("disabled")
     expect(getByLabelText("Three", { exact: false })).toHaveProperty("disabled")
   })
 

--- a/src/components/filters/checkbox.tsx
+++ b/src/components/filters/checkbox.tsx
@@ -24,7 +24,7 @@ const CheckboxFilter: FC<Props> = ({
   options,
   apply: applyFilters,
   selected = [],
-  facet = {},
+  facet,
   onSelect,
 }) => {
   const values = options.map(({ value }) => value)
@@ -52,8 +52,8 @@ const CheckboxFilter: FC<Props> = ({
 
   const renderOption = ({ value, label, renderIcon }: Item) => {
     const isSelected = selected.includes(value)
-    const resultsCount = facet[value.toString()] || 0
-    const hasFacet = Object.keys(facet).length > 0
+    const resultsCount = facet?.[value.toString()] || 0
+    const hasFacet = !!facet
     const isDisabled = hasFacet && resultsCount === 0 && !isSelected
 
     return (


### PR DESCRIPTION
Fixes: CAR-8720

### Background:

So far we checked if facet exists based on the presence of any keys in the facet object and we defaulted to an empty one. This made it impossible to distinguish whether the facet object is not present or empty. In a case where every checkbox in the entire filter would result in zero results, we would treat it as if there were no facets not showing anything and having checkboxes enabled.

The fix on the API level would be tricky and require some post-processing. It would have a negative impact on performance and it's not really feasible.
Instead, we can leverage that an object (even an empty one) is considered truthy so we can roll with a simple `null` check to validate wether we have a facet or it failed to fetch. 