### PR TITLE
fix: react-paginate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26628,9 +26628,9 @@
       "dev": true
     },
     "react-paginate": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-7.1.1.tgz",
-      "integrity": "sha512-LJJUJxThsnIhnpc01ooJHFvbl6+FcNNIQgaiv1cFK15w2tBVp7J42S70YEX/mXwHNOCZCLSTMHsEEAi0gDt2OA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-7.1.5.tgz",
+      "integrity": "sha512-CpyWSwsIIsFhWAQvmXDWuEl+yzfzisgvsUoZTj2IR1mFvm9oPTmeNBFc1wg8/i6ASmETeOmOnc78/U/MXyjd0w==",
       "requires": {
         "prop-types": "^15.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "glob": "^7.1.6",
     "lodash.debounce": "^4.0.8",
     "react-calendar": "^3.3.1",
-    "react-paginate": "7.1.1",
+    "react-paginate": "^7.1.5",
     "react-tooltip-lite": "npm:@carforyou/react-tooltip-lite@1.12.1",
     "tailwindcss-gradients": "^2.0.0",
     "use-deep-compare-effect": "^1.4.0"


### PR DESCRIPTION
`react-paginate` was broken yesterday, we downgraded to v 7.1.1 as a temporary fix but today we have a fixed release from react-paginate. 