### PR TITLE
fix: CLS above the fold for the new range filter

### DIFF
--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -204,6 +204,7 @@ Object {
       "full": "100%",
       "input": "52px",
       "radioIndicator": "12px",
+      "rangeFilterChart": "118px",
       "screen": "100vh",
       "scrollbar": "70px",
     },

--- a/src/components/filters/rangeWithFacets/chart.module.css
+++ b/src/components/filters/rangeWithFacets/chart.module.css
@@ -1,3 +1,0 @@
-.chart {
-    height: 118px;
-}

--- a/src/components/filters/rangeWithFacets/chart.tsx
+++ b/src/components/filters/rangeWithFacets/chart.tsx
@@ -1,8 +1,6 @@
 import React from "react"
 import classNames from "classnames"
 
-import styles from "./chart.module.css"
-
 interface Props {
   facets?: Record<string, number>
   range: [number, number]
@@ -13,7 +11,7 @@ const Chart: React.FC<Props> = ({ facets, range }) => {
 
   const maxValue = Math.max(...Object.values(facets))
   return (
-    <div className={classNames("w-12/12 flex justify-between", styles.chart)}>
+    <div className="w-12/12 flex justify-between h-rangeFilterChart">
       {Object.keys(facets).map((facet, index) => (
         <div
           key={facet}

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -213,6 +213,7 @@ export default {
       checkbox: "24px",
       radioIndicator: "12px",
       input: "52px",
+      rangeFilterChart: "118px",
       "20": "20px",
       "40": "40px",
     },


### PR DESCRIPTION
CSS modules kick in too late. Since the new filter for price is above the fold, this results in a layout shift. Using global CSS with tailwind hopefully solves this issue.