### PR TITLE
fix: not sorted ranges and all facets 0

### DIFF
--- a/src/components/filters/rangeWithFacets/__tests__/chart.test.tsx
+++ b/src/components/filters/rangeWithFacets/__tests__/chart.test.tsx
@@ -86,4 +86,26 @@ describe("<Chart/>", () => {
       transform: "scaleY(0.6)",
     })
   })
+
+  it("if all facets are 0, scale should be 0", () => {
+    const screen = render(
+      <Chart
+        facets={{
+          "*-1000": 0,
+          "22500-25000": 0,
+          "1000-2000": 0,
+          "1000000-*": 0,
+          "2000-22500": 0,
+        }}
+        scale={mockScale}
+        range={[1, 3]}
+      />
+    )
+
+    screen.getAllByTestId("facet").forEach((facet) =>
+      expect(facet).toHaveStyle({
+        transform: "scaleY(0)",
+      })
+    )
+  })
 })

--- a/src/components/filters/rangeWithFacets/__tests__/chart.test.tsx
+++ b/src/components/filters/rangeWithFacets/__tests__/chart.test.tsx
@@ -5,25 +5,59 @@ import Chart from "../chart"
 
 const mockFacets = {
   "*-1000": 500,
-  "1000-2000": 200,
-  "2000-22500": 130,
   "22500-25000": 50,
+  "1000-2000": 200,
   "1000000-*": 300,
+  "2000-22500": 130,
 }
+
+const mockScale = [
+  {
+    from: null,
+    to: 1000,
+    key: "*-1000",
+  },
+  {
+    from: 1000,
+    to: 2000,
+    key: "1000-2000",
+  },
+  {
+    from: 2000,
+    to: 22500,
+    key: "2000-22500",
+  },
+  {
+    from: 22500,
+    to: 25000,
+    key: "22500-25000",
+  },
+  {
+    from: 1000000,
+    to: null,
+    key: "1000000-*",
+  },
+]
 
 describe("<Chart/>", () => {
   it("renders nothing when facets is not defined (backend failure)", () => {
-    const screen = render(<Chart facets={undefined} range={[2, 4]} />)
+    const screen = render(
+      <Chart facets={undefined} scale={mockScale} range={[2, 4]} />
+    )
     expect(screen.container.firstChild).toBeNull()
   })
 
   it("renders a bar for each facet", () => {
-    const screen = render(<Chart facets={mockFacets} range={[2, 4]} />)
+    const screen = render(
+      <Chart facets={mockFacets} scale={mockScale} range={[2, 4]} />
+    )
     expect(screen.getAllByTestId("facet")).toHaveLength(5)
   })
 
   it("shows the bars outside of the range as grey", () => {
-    const screen = render(<Chart facets={mockFacets} range={[1, 3]} />)
+    const screen = render(
+      <Chart facets={mockFacets} scale={mockScale} range={[1, 3]} />
+    )
     expect(screen.getAllByTestId("facet")[0]).toHaveClass("bg-grey-1")
     expect(screen.getAllByTestId("facet")[1]).toHaveClass("bg-teal")
     expect(screen.getAllByTestId("facet")[2]).toHaveClass("bg-teal")
@@ -32,13 +66,24 @@ describe("<Chart/>", () => {
   })
 
   it("scales the bar depending on the facet", () => {
-    const screen = render(<Chart facets={mockFacets} range={[1, 3]} />)
+    const screen = render(
+      <Chart facets={mockFacets} scale={mockScale} range={[1, 3]} />
+    )
     // max value has 1
     expect(screen.getAllByTestId("facet")[0]).toHaveStyle({
       transform: "scaleY(1)",
     })
     expect(screen.getAllByTestId("facet")[1]).toHaveStyle({
       transform: "scaleY(0.4)",
+    })
+    expect(screen.getAllByTestId("facet")[2]).toHaveStyle({
+      transform: "scaleY(0.26)",
+    })
+    expect(screen.getAllByTestId("facet")[3]).toHaveStyle({
+      transform: "scaleY(0.1)",
+    })
+    expect(screen.getAllByTestId("facet")[4]).toHaveStyle({
+      transform: "scaleY(0.6)",
     })
   })
 })

--- a/src/components/filters/rangeWithFacets/__tests__/rangeFilterScale.test.ts
+++ b/src/components/filters/rangeWithFacets/__tests__/rangeFilterScale.test.ts
@@ -28,6 +28,26 @@ describe("RangeFilterScale", () => {
     ])
   })
 
+  it("creates a correct scale when the object is not ordered", () => {
+    const range = RangeFilterScale.toRange({
+      30000: 10000,
+      3000: 1000,
+      10000: 2000,
+      8000: 2500,
+    })
+    expect(range).toEqual([
+      { from: null, key: "*-1000", to: 1000 },
+      { from: 1000, key: "1000-2000", to: 2000 },
+      { from: 2000, key: "2000-3000", to: 3000 },
+      { from: 3000, key: "3000-5500", to: 5500 },
+      { from: 5500, key: "5500-8000", to: 8000 },
+      { from: 8000, key: "8000-10000", to: 10000 },
+      { from: 10000, key: "10000-20000", to: 20000 },
+      { from: 20000, key: "20000-30000", to: 30000 },
+      { from: 30000, key: "30000-*", to: null },
+    ])
+  })
+
   it("returns the correct values for the min value", () => {
     const myRange = new RangeFilterScale(mockRange)
     expect(myRange.toRange({ min: 0, max: null })).toEqual([0, 9])

--- a/src/components/filters/rangeWithFacets/chart.tsx
+++ b/src/components/filters/rangeWithFacets/chart.tsx
@@ -28,7 +28,9 @@ const Chart: React.FC<Props> = ({ facets, scale, range }) => {
             transitionProperty: "transform",
             transitionDuration: "1s",
             transformOrigin: "bottom",
-            transform: `scaleY(${facets[scaleElement.key] / maxValue})`,
+            transform: `scaleY(${
+              maxValue ? facets[scaleElement.key] / maxValue : 0
+            })`,
           }}
         />
       ))}

--- a/src/components/filters/rangeWithFacets/chart.tsx
+++ b/src/components/filters/rangeWithFacets/chart.tsx
@@ -1,22 +1,24 @@
 import React from "react"
 import classNames from "classnames"
 
+import { RangeElement } from "./rangeFilterScale"
 import styles from "./chart.module.css"
 
 interface Props {
   facets?: Record<string, number>
+  scale: RangeElement[]
   range: [number, number]
 }
 
-const Chart: React.FC<Props> = ({ facets, range }) => {
+const Chart: React.FC<Props> = ({ facets, scale, range }) => {
   if (!facets) return null
 
   const maxValue = Math.max(...Object.values(facets))
   return (
     <div className={classNames("w-12/12 flex justify-between", styles.chart)}>
-      {Object.keys(facets).map((facet, index) => (
+      {scale.map((scaleElement, index) => (
         <div
-          key={facet}
+          key={scaleElement.key}
           data-testid="facet"
           className={classNames(
             "h-full inline-block flex-grow mx-px",
@@ -26,7 +28,7 @@ const Chart: React.FC<Props> = ({ facets, range }) => {
             transitionProperty: "transform",
             transitionDuration: "1s",
             transformOrigin: "bottom",
-            transform: `scaleY(${facets[facet] / maxValue})`,
+            transform: `scaleY(${facets[scaleElement.key] / maxValue})`,
           }}
         />
       ))}

--- a/src/components/filters/rangeWithFacets/chart.tsx
+++ b/src/components/filters/rangeWithFacets/chart.tsx
@@ -29,7 +29,7 @@ const Chart: React.FC<Props> = ({ facets, scale, range }) => {
             transitionDuration: "1s",
             transformOrigin: "bottom",
             transform: `scaleY(${
-              maxValue ? facets[scaleElement.key] / maxValue : 0
+              maxValue > 0 ? facets[scaleElement.key] / maxValue : 0
             })`,
           }}
         />

--- a/src/components/filters/rangeWithFacets/sliderWithChart.tsx
+++ b/src/components/filters/rangeWithFacets/sliderWithChart.tsx
@@ -57,7 +57,11 @@ const SliderWithChart: React.FC<Props> = ({
       )}
       renderTrack={({ props, children }) => (
         <div className="w-12/12 flex flex-col">
-          <Chart facets={facets} range={range.toRange(selection)} />
+          <Chart
+            facets={facets}
+            scale={scale}
+            range={range.toRange(selection)}
+          />
           <div
             {...props}
             className="w-12/12 h-4 self-center mt-px"

--- a/src/stories/filters/rangeWithFacets.stories.tsx
+++ b/src/stories/filters/rangeWithFacets.stories.tsx
@@ -24,6 +24,18 @@ const exampleFacets = {
   "20000-30000": 647,
 }
 
+const exampleFacetsWithEmptyResults = {
+  "*-1000": 0,
+  "5500-8000": 0,
+  "1000-2000": 0,
+  "10000-20000": 0,
+  "2000-3000": 0,
+  "3000-5500": 0,
+  "30000-*": 0,
+  "8000-10000": 0,
+  "20000-30000": 0,
+}
+
 const Wrapper = (props) => {
   const [value, setValue] = useState(props.value)
 
@@ -85,9 +97,26 @@ Default.args = {
   subtext: "(1450 Autos)",
 }
 
+export const WithEmptyFacets = Template.bind({})
+WithEmptyFacets.args = {
+  storyName: "WithEmptyFacets",
+  scale: exampleScale,
+  facets: exampleFacetsWithEmptyResults,
+  inputName: {
+    min: "priceFrom",
+    max: "priceTo",
+  },
+  value: {
+    min: 5000,
+    max: 25000,
+  },
+  unit: "CHF",
+  subtext: "(1450 Autos)",
+}
+
 export const WithoutFacets = Template.bind({})
 WithoutFacets.args = {
-  storyName: "Default",
+  storyName: "WithoutFacets",
   scale: exampleScale,
   inputName: {
     min: "priceFrom",

--- a/src/stories/filters/rangeWithFacets.stories.tsx
+++ b/src/stories/filters/rangeWithFacets.stories.tsx
@@ -12,17 +12,17 @@ const exampleScale = RangeFilterScale.toRange({
   30000: 10000,
 })
 
-const createDummyFacets = () => {
-  const facets = {}
-  exampleScale.forEach((scale) => {
-    facets[`${scale.from || "*"}-${scale.to || "*"}`] = Math.floor(
-      Math.random() * (1000 - 100 + 1) + 100
-    )
-  })
-  return facets
+const exampleFacets = {
+  "*-1000": 481,
+  "5500-8000": 167,
+  "1000-2000": 854,
+  "10000-20000": 318,
+  "2000-3000": 650,
+  "3000-5500": 786,
+  "30000-*": 837,
+  "8000-10000": 922,
+  "20000-30000": 647,
 }
-
-const exampleFacets = createDummyFacets()
 
 const Wrapper = (props) => {
   const [value, setValue] = useState(props.value)


### PR DESCRIPTION
Fixes the following issues:

Not sorted facets -> bar is shown even though there are 0 results
![image](https://user-images.githubusercontent.com/71456764/140074713-e7921db1-5370-4c92-a26d-ba7d62ec3b3c.png)

When all facets are 0 it looks like this (division by 0 :( )
![image](https://user-images.githubusercontent.com/71456764/140074907-461d8fbf-604a-4df4-84cc-eeb7fdb18a78.png)

