### PR TITLE
feat: improve mobile range filter

### DIFF
--- a/src/components/filters/rangeWithFacets/index.tsx
+++ b/src/components/filters/rangeWithFacets/index.tsx
@@ -97,7 +97,7 @@ const RangeFilterWithFacets: React.FC<Props> = ({
   }
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center pb-20 md:pb-0">
       <div className="flex flex-col-reverse md:flex-col md:space-y-25">
         <SliderWithChart
           onChange={onSliderChange}

--- a/src/components/filters/rangeWithFacets/index.tsx
+++ b/src/components/filters/rangeWithFacets/index.tsx
@@ -98,7 +98,7 @@ const RangeFilterWithFacets: React.FC<Props> = ({
 
   return (
     <div className="flex flex-col items-center">
-      <div className="space-y-25">
+      <div className="flex flex-col-reverse md:flex-col md:space-y-25">
         <SliderWithChart
           onChange={onSliderChange}
           onSliderRelease={onSliderRelease}
@@ -113,7 +113,7 @@ const RangeFilterWithFacets: React.FC<Props> = ({
           value={appliedValue()}
         />
       </div>
-      <p className="text-grey-3">{subtext}</p>
+      <p className="text-grey-3 mt-25 md:mt-0">{subtext}</p>
     </div>
   )
 }

--- a/src/components/filters/rangeWithFacets/index.tsx
+++ b/src/components/filters/rangeWithFacets/index.tsx
@@ -113,7 +113,7 @@ const RangeFilterWithFacets: React.FC<Props> = ({
           value={appliedValue()}
         />
       </div>
-      <p className="text-grey-3 mt-25 md:mt-0">{subtext}</p>
+      <p className="hidden md:block text-grey-3">{subtext}</p>
     </div>
   )
 }

--- a/src/components/filters/rangeWithFacets/sliderWithChart.tsx
+++ b/src/components/filters/rangeWithFacets/sliderWithChart.tsx
@@ -56,7 +56,7 @@ const SliderWithChart: React.FC<Props> = ({
         />
       )}
       renderTrack={({ props, children }) => (
-        <div className="w-12/12 flex flex-col px-15 md:px-0">
+        <div className="w-12/12 flex flex-col px-20 md:px-0">
           <Chart
             facets={facets}
             scale={scale}

--- a/src/components/filters/rangeWithFacets/sliderWithChart.tsx
+++ b/src/components/filters/rangeWithFacets/sliderWithChart.tsx
@@ -56,7 +56,7 @@ const SliderWithChart: React.FC<Props> = ({
         />
       )}
       renderTrack={({ props, children }) => (
-        <div className="w-12/12 flex flex-col">
+        <div className="w-12/12 flex flex-col px-15 md:px-0">
           <Chart
             facets={facets}
             scale={scale}


### PR DESCRIPTION
References: [CAR-9092](https://autoricardo.atlassian.net/browse/CAR-9092)

When the filter is being used on mobile at the moment, the thumb covers the input field while sliding. As a result, the user cannot see the current value. Furthermore, many smartphones have gestures on the side of the screen. Sometimes those are dragged instead of the slider end.

Before

![Screenshot_20211110_131601_com opera browser](https://user-images.githubusercontent.com/71456764/141111580-280c5505-4d0f-4587-9d71-8043b0a615e8.jpg)

After
![Screenshot_20211110_131606_com opera browser](https://user-images.githubusercontent.com/71456764/141111611-6becf7d1-6318-4073-8b89-82d9d748e602.jpg)