### PR TITLE
fix: use `button` tag for modal close button

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -57,7 +57,7 @@ const Modal: FC<ModalProps> = ({
   }, [])
 
   const renderCloseIcon = () => (
-    <div
+    <button
       className={classNames(
         "z-modalClose cursor-pointer",
         title ? "self-start" : "absolute right-modalClose top-modalClose"
@@ -66,7 +66,7 @@ const Modal: FC<ModalProps> = ({
       data-testid="modal-close"
     >
       <CloseMIcon width="48" height="48" />
-    </div>
+    </button>
   )
 
   return (

--- a/src/hooks/__tests__/__snapshots__/useModal.test.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/useModal.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`useModal with a portal renders the modal within the portal 1`] = `
       <div
         class="z-modal w-12/12 my-0 p-15 md:p-40 md:w-modal"
       >
-        <div
+        <button
           class="z-modalClose cursor-pointer absolute right-modalClose top-modalClose"
           data-testid="modal-close"
         >
@@ -39,7 +39,7 @@ exports[`useModal with a portal renders the modal within the portal 1`] = `
               stroke="currentColor"
             />
           </svg>
-        </div>
+        </button>
         <div>
           HERE BE DRAGONS
         </div>
@@ -91,7 +91,7 @@ exports[`useModal without portal renders the modal within the container 1`] = `
         <div
           class="z-modal w-12/12 my-0 p-15 md:p-40 md:w-modal"
         >
-          <div
+          <button
             class="z-modalClose cursor-pointer absolute right-modalClose top-modalClose"
             data-testid="modal-close"
           >
@@ -112,7 +112,7 @@ exports[`useModal without portal renders the modal within the container 1`] = `
                 stroke="currentColor"
               />
             </svg>
-          </div>
+          </button>
           <div>
             HERE BE DRAGONS
           </div>


### PR DESCRIPTION
References: [CAR-9077](https://autoricardo.atlassian.net/browse/CAR-9077)

Switches modal close button from `div` to a `button` so that it can be interacted with via voice over.
