### PR TITLE
fix: added missing tailwind value

### DIFF
--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -424,6 +424,7 @@ Object {
       "card": 10,
       "clearButton": 10,
       "dropdownMenu": 20,
+      "flashMessage": 99,
       "intercom": 10,
       "modal": 98,
       "modalClose": 10,

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -518,6 +518,7 @@ export default {
       modal: 98,
       card: 10,
       intercom: 10,
+      flashMessage: 99,
     },
 
     /*


### PR DESCRIPTION
Reference: https://github.com/carforyou/carforyou-dealerhub-web/pull/1707

## Motivation
While I was exporting the flash message component I noticed that we were missing the z-index value.

# Thank you 🐥