### PR TITLE
fix: removing z-index for clear icon

### DIFF
--- a/src/__tests__/__snapshots__/node.test.ts.snap
+++ b/src/__tests__/__snapshots__/node.test.ts.snap
@@ -422,7 +422,6 @@ Object {
       "1": 1,
       "auto": "auto",
       "card": 10,
-      "clearButton": 10,
       "dropdownMenu": 20,
       "flashMessage": 99,
       "intercom": 10,

--- a/src/components/fieldHelpers/withClearButton.tsx
+++ b/src/components/fieldHelpers/withClearButton.tsx
@@ -23,7 +23,7 @@ const WithClearButton: FC<Props> = ({
           tabIndex={-1}
           data-testid="clearButton"
           className={classNames(
-            "absolute top-0 right-0 bottom-0 cursor-pointer z-clearButton outline-none w-clearButton focus:outline-none",
+            "absolute top-0 right-0 bottom-0 cursor-pointer outline-none w-clearButton focus:outline-none",
             { "opacity-20": disabled }
           )}
           onClick={!disabled ? onClear : null}

--- a/src/tailwind/defaultConfig.ts
+++ b/src/tailwind/defaultConfig.ts
@@ -512,7 +512,6 @@ export default {
       1: 1,
       auto: "auto",
       negative: -1,
-      clearButton: 10,
       modalClose: 10,
       dropdownMenu: 20,
       modal: 98,


### PR DESCRIPTION
Reference: [CAR-9313](https://autoricardo.atlassian.net/browse/CAR-9313)

We have a bug with the clear icon in the input field because of the **z-index**, now it's removed. I have a [follow-up ticket for UL](https://github.com/carforyou/carforyou-listings-web/pull/3872) for **QA** to check.

[cleanup for DH](https://github.com/carforyou/carforyou-dealerhub-web/pull/1722)