### PR TITLE
feat: allow to pass a placeholder to the range filter

### DIFF
--- a/src/components/filters/rangeWithFacets/__tests__/index.test.tsx
+++ b/src/components/filters/rangeWithFacets/__tests__/index.test.tsx
@@ -29,6 +29,10 @@ const inputName = {
   min: "priceFrom",
   max: "priceTo",
 }
+const inputPlaceholder = {
+  min: "priceFromPlaceholder",
+  max: "priceToPlaceholder",
+}
 const mockTracking = jest.fn()
 
 describe("<RangeFilterWithFacets/>", () => {
@@ -38,6 +42,7 @@ describe("<RangeFilterWithFacets/>", () => {
         addFilter={mockAddFilter}
         facets={mockFacets}
         inputName={inputName}
+        inputPlaceholder={inputPlaceholder}
         scale={mockScale}
         tracking={mockTracking}
         value={value}
@@ -91,6 +96,12 @@ describe("<RangeFilterWithFacets/>", () => {
         },
         { timeout: 1500 }
       )
+    })
+
+    it("shows a placeholder", () => {
+      const screen = renderScreen()
+      expect(screen.getByPlaceholderText(inputPlaceholder.min))
+      expect(screen.getByPlaceholderText(inputPlaceholder.max))
     })
   })
 

--- a/src/components/filters/rangeWithFacets/index.tsx
+++ b/src/components/filters/rangeWithFacets/index.tsx
@@ -34,12 +34,12 @@ interface Props {
     min: string
     max: string
   }
-  inputPlaceholder: {
+  inputPlaceholder?: {
     min: string
     max: string
   }
   value: NumericMinMaxValue
-  unit: string
+  unit?: string
   subtext: string
   addFilter: (values: NumericMinMaxValue) => void
   tracking: (event: TrackingEvent) => void

--- a/src/components/filters/rangeWithFacets/index.tsx
+++ b/src/components/filters/rangeWithFacets/index.tsx
@@ -34,6 +34,10 @@ interface Props {
     min: string
     max: string
   }
+  inputPlaceholder: {
+    min: string
+    max: string
+  }
   value: NumericMinMaxValue
   unit: string
   subtext: string
@@ -45,6 +49,7 @@ const RangeFilterWithFacets: React.FC<Props> = ({
   scale,
   facets,
   inputName,
+  inputPlaceholder,
   value,
   unit,
   subtext,
@@ -111,6 +116,7 @@ const RangeFilterWithFacets: React.FC<Props> = ({
           handleChange={syncSliderWithInput}
           unit={unit}
           value={appliedValue()}
+          placeholder={inputPlaceholder}
         />
       </div>
       <p className="hidden md:block text-grey-3">{subtext}</p>

--- a/src/components/filters/rangeWithFacets/rangeInputWithUnit.tsx
+++ b/src/components/filters/rangeWithFacets/rangeInputWithUnit.tsx
@@ -40,7 +40,7 @@ const RangeInputWithUnit: FC<Props> = ({
   }
 
   const unitElement = unit ? (
-    <p className="absolute z-1 mt-16 ml-10 text-grey-3">{unit}</p>
+    <p className="absolute z-1 mt-16 pt-px ml-10 text-grey-3">{unit}</p>
   ) : null
 
   return (

--- a/src/components/filters/rangeWithFacets/rangeInputWithUnit.tsx
+++ b/src/components/filters/rangeWithFacets/rangeInputWithUnit.tsx
@@ -15,7 +15,7 @@ interface Props {
     max: number
   }
   unit?: string
-  placeholder: {
+  placeholder?: {
     min: string
     max: string
   }
@@ -56,7 +56,7 @@ const RangeInputWithUnit: FC<Props> = ({
             hasClearButton={false}
             textAlignment="right"
             apply={(e) => onChange(e, el)}
-            placeholder={placeholder[el]}
+            placeholder={placeholder && placeholder[el]}
           />
         </div>
       ))}

--- a/src/components/filters/rangeWithFacets/rangeInputWithUnit.tsx
+++ b/src/components/filters/rangeWithFacets/rangeInputWithUnit.tsx
@@ -14,10 +14,20 @@ interface Props {
     min: number
     max: number
   }
-  unit: string
+  unit?: string
+  placeholder: {
+    min: string
+    max: string
+  }
 }
 
-const RangeInputWithUnit: FC<Props> = ({ name, handleChange, value, unit }) => {
+const RangeInputWithUnit: FC<Props> = ({
+  name,
+  handleChange,
+  value,
+  unit,
+  placeholder,
+}) => {
   const onChange = ({ target }, editedField: "min" | "max") => {
     const { value: changedValue } = target
     handleChange({
@@ -29,37 +39,27 @@ const RangeInputWithUnit: FC<Props> = ({ name, handleChange, value, unit }) => {
     })
   }
 
-  const unitElement = (
+  const unitElement = unit ? (
     <p className="absolute z-1 mt-16 ml-10 text-grey-3">{unit}</p>
-  )
+  ) : null
 
   return (
     <div className="w-12/12 flex">
-      <div className="relative">
-        {unitElement}
-        <InputFilter
-          name={name.min}
-          initialValue={value.min ? String(value.min) : undefined}
-          mode="numeric"
-          position="left"
-          hasClearButton={false}
-          textAlignment="right"
-          apply={(e) => onChange(e, "min")}
-        />
-      </div>
-
-      <div className="relative">
-        {unitElement}
-        <InputFilter
-          name={name.max}
-          initialValue={value.max ? String(value.max) : undefined}
-          mode="numeric"
-          position="right"
-          hasClearButton={false}
-          textAlignment="right"
-          apply={(e) => onChange(e, "max")}
-        />
-      </div>
+      {Object.keys(value).map((el: "min" | "max") => (
+        <div className="relative" key={el}>
+          {unitElement}
+          <InputFilter
+            name={name[el]}
+            initialValue={value[el] ? String(value[el]) : undefined}
+            mode="numeric"
+            position={el === "min" ? "left" : "right"}
+            hasClearButton={false}
+            textAlignment="right"
+            apply={(e) => onChange(e, el)}
+            placeholder={placeholder[el]}
+          />
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/stories/filters/rangeWithFacets.stories.tsx
+++ b/src/stories/filters/rangeWithFacets.stories.tsx
@@ -151,10 +151,7 @@ WithoutUnit.args = {
     min: "priceFrom",
     max: "priceTo",
   },
-  inputPlaceholder: {
-    min: "0",
-    max: "30000+",
-  },
+
   value: {
     min: null,
     max: null,

--- a/src/stories/filters/rangeWithFacets.stories.tsx
+++ b/src/stories/filters/rangeWithFacets.stories.tsx
@@ -89,9 +89,13 @@ Default.args = {
     min: "priceFrom",
     max: "priceTo",
   },
+  inputPlaceholder: {
+    min: "0",
+    max: "30000+",
+  },
   value: {
-    min: 5000,
-    max: 25000,
+    min: null,
+    max: null,
   },
   unit: "CHF",
   subtext: "(1450 Autos)",
@@ -106,9 +110,13 @@ WithEmptyFacets.args = {
     min: "priceFrom",
     max: "priceTo",
   },
+  inputPlaceholder: {
+    min: "0",
+    max: "30000+",
+  },
   value: {
-    min: 5000,
-    max: 25000,
+    min: null,
+    max: null,
   },
   unit: "CHF",
   subtext: "(1450 Autos)",
@@ -122,10 +130,34 @@ WithoutFacets.args = {
     min: "priceFrom",
     max: "priceTo",
   },
+  inputPlaceholder: {
+    min: "0",
+    max: "30000+",
+  },
   value: {
-    min: 5000,
-    max: 25000,
+    min: null,
+    max: null,
   },
   unit: "CHF",
+  subtext: "(1450 Autos)",
+}
+
+export const WithoutUnit = Template.bind({})
+WithoutUnit.args = {
+  storyName: "WithoutUnit",
+  scale: exampleScale,
+  facets: exampleFacets,
+  inputName: {
+    min: "priceFrom",
+    max: "priceTo",
+  },
+  inputPlaceholder: {
+    min: "0",
+    max: "30000+",
+  },
+  value: {
+    min: null,
+    max: null,
+  },
   subtext: "(1450 Autos)",
 }


### PR DESCRIPTION
References: [CAR-9093](https://autoricardo.atlassian.net/browse/CAR-9093)

The slider should be able to show a placeholder to help the user understand possible values. Furthermore, the year field does not have a unit thus it needs to get changed to optional. 
You can see how it looks here: https://github.com/carforyou/carforyou-listings-web/pull/3840