### PR TITLE
chore: add viewport addon

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,2 +1,29 @@
-import "./stories.css"
-import "../assets/index.css"
+require("../assets/index.css")
+require("./stories.css")
+
+import { addParameters } from '@storybook/react';
+
+const screens = {
+  xxs: '375px',
+  xs: '480px',
+  sm: '576px',
+  md: '768px',
+  lg: '1024px',
+  xl: '1280px',
+  xxl: '1920px'
+}
+
+const customViewports = Object.entries(screens).reduce((acc, [key, value]) => {
+  acc[key] = {
+    name: key,
+    styles: {
+      width: value,
+      height: "100%"
+    }
+  }
+  return acc
+}, {})
+
+addParameters({
+  viewport: { viewports: customViewports },
+})

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,19 +1,11 @@
 require("../assets/index.css")
 require("./stories.css")
 
+const tailwindConfig = require("../.tailwind/defaultConfig").default
+
 import { addParameters } from '@storybook/react';
 
-const screens = {
-  xxs: '375px',
-  xs: '480px',
-  sm: '576px',
-  md: '768px',
-  lg: '1024px',
-  xl: '1280px',
-  xxl: '1920px'
-}
-
-const customViewports = Object.entries(screens).reduce((acc, [key, value]) => {
+const customViewports = Object.entries(tailwindConfig.theme.screens).reduce((acc, [key, value]) => {
   acc[key] = {
     name: key,
     styles: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@pika/plugin-ts-standard-pkg": "0.9.2",
         "@storybook/addon-essentials": "6.4.9",
         "@storybook/addon-postcss": "2.0.0",
+        "@storybook/addon-viewport": "6.4.9",
         "@storybook/react": "6.4.9",
         "@testing-library/jest-dom": "5.16.1",
         "@testing-library/react": "12.1.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@pika/plugin-ts-standard-pkg": "0.9.2",
     "@storybook/addon-essentials": "6.4.9",
     "@storybook/addon-postcss": "2.0.0",
+    "@storybook/addon-viewport": "6.4.9",
     "@storybook/react": "6.4.9",
     "@testing-library/jest-dom": "5.16.1",
     "@testing-library/react": "12.1.2",


### PR DESCRIPTION
## Motivation
While I was checking a branch I found that the Storybook Viewport Addon was removed.

Storybook Viewport Addon -> https://storybook.js.org/docs/react/essentials/viewport

I used a lot that addon when I'm working on Storybook. And now that we have the branch deployments on components and header-footer I think, it will be a good practice to use this nice addon that Story provide us.

Maybe you are thinking -> but we can resize the window!. Yes, you can. BUT remember that you are resizing the Storybook itself as well and no ONLY the component.

## Take into consideration
I added a configuration for the breakpoints.

![Screenshot 2022-01-04 at 17 53 03](https://user-images.githubusercontent.com/37380787/148094803-51e68673-3506-4692-89fb-2a4502e8f3e8.png)

# Thank you 🛎