### PR TITLE
chore: remove ghpages script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "build:assets": "npx cfy-assets build",
     "build:storybook": "npm run build:tailwind && build-storybook",
     "bundlesize": "bundlesize",
-    "deploy": "storybook-to-ghpages",
     "typecheck": "tsc --noEmit"
   },
   "repository": {


### PR DESCRIPTION
## Motivation
In the fronted-alerts channel the component jobs are failing in the deploy statement because it cannot find `storybook-to-ghpages` script because I've disabled the gitHub pages (we have now the branch deployment, no need to have the gitHub page).

# Thank you ☃️