### PR TITLE
chore: removed deploy in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,15 +82,6 @@ jobs:
       - slack/notify-on-failure:
           only_for_branches: master
 
-  deploy:
-    <<: *DOCKER_NODE
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: npm run deploy -- --existing-output-dir=~/project/storybook-static --ci
-      - slack/notify-on-failure:
-          only_for_branches: master
-
   release:
     <<: *DOCKER_NODE
     steps:
@@ -158,14 +149,6 @@ workflows:
       - typecheck:
           requires:
             - build
-
-      - deploy:
-          requires:
-            - unit
-            - build
-          filters:
-            branches:
-              only: master
 
       - release:
           requires:


### PR DESCRIPTION
References: https://app.circleci.com/pipelines/github/carforyou/carforyou-components-pkg/4360/workflows/a05dd17f-d983-4367-bf7d-6946948a527e/jobs/14194

## Take into consideration
The deploy scrip was removed, but on CI it still tries to deploy the gh-pages.

# Thank you 🙈