### PR TITLE
Car 9534: new component "radioButtonGroupWithTitle"

### DIFF
--- a/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
+++ b/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
@@ -3,11 +3,9 @@ import React, { FC } from "react"
 import { action } from "@storybook/addon-actions"
 
 import { StoryProps } from "./storyProps"
-import StoryContainer from "./storyContainer"
 import RadioButtonGroupWithTitle, { RadioButtonGroupProps } from "../../src/components/radioButtonGroupWithTitle"
 
 const onChange = () => action("onChange")
-const initialValue = "B"
 
 export default {
   title: "Radio Button Group with Title",
@@ -15,11 +13,19 @@ export default {
   args: {
     storyName: "",
     title: "Radio Group",
-    value: initialValue,
-    checked: false,
-    onChange: (e) => {
-      onChange()(e)
-    },
+    radioInputs: [{name: "radioButtonGroupWithTitle", value: "A",
+  checked: false,
+  onChange: (e) => {
+    onChange()(e)
+  }, renderLabel:() => "option 1"}, {name: "radioButtonGroupWithTitle", value: "B",
+  checked: false,
+  onChange: (e) => {
+    onChange()(e)
+  }, renderLabel:() => "option 2"}, {name: "radioButtonGroupWithTitle", value: "C",
+  checked: false,
+  onChange: (e) => {
+    onChange()(e)
+  }, renderLabel:() => "option 3"}]
   },
   argTypes: {
     storyName: {
@@ -35,7 +41,7 @@ interface Props extends StoryProps<JSX.Element>, RadioButtonGroupProps {}
 const Template: FC<Props> = (args) => {
   return (
       <>
-    <div className="text-2xl mb-20">{args.title}</div>
+    <div className="text-2xl mb-20">{args.storyName}</div>
         <RadioButtonGroupWithTitle
           {...args}
         />
@@ -46,31 +52,17 @@ const Template: FC<Props> = (args) => {
 
 export const Standard = Template.bind({})
 Standard.args = {
-    required: true,
-  storyName: "Standard",
-  radioInputs: [{name: "radioButtonGroupWithTitle", value: initialValue,
-  checked: false,
-  onChange: (e) => {
-    onChange()(e)
-  }, renderLabel:() => "labelgff fgfgdg"}, {name: "radioButtonGroupWithTitle", value: initialValue,
-  checked: false,
-  onChange: (e) => {
-    onChange()(e)
-  }, renderLabel:() => "label"}, {name: "radioButtonGroupWithTitle", value: initialValue,
-  checked: false,
-  onChange: (e) => {
-    onChange()(e)
-  }, renderLabel:() => "label"}, {name: "radioButtonGroupWithTitle", value: initialValue,
-  checked: false,
-  onChange: (e) => {
-    onChange()(e)
-  }, renderLabel:() => "label"}, {name: "radioButtonGroupWithTitle", value: initialValue,
-  checked: false,
-  onChange: (e) => {
-    onChange()(e)
-  }, renderLabel:() => "label"}, {name: "radioButtonGroupWithTitle", value: initialValue,
-  checked: false,
-  onChange: (e) => {
-    onChange()(e)
-  }, renderLabel:() => "label"}]
+    storyName: "Standard",
+}
+
+export const Disabled = Template.bind({})
+Disabled.args = {
+  storyName: "Disabled",
+  disabled: true,
+}
+
+export const Required = Template.bind({})
+Required.args = {
+  storyName: "Required",
+  required: true,
 }

--- a/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
+++ b/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
@@ -1,0 +1,76 @@
+import React, { FC } from "react"
+
+import { action } from "@storybook/addon-actions"
+
+import { StoryProps } from "./storyProps"
+import StoryContainer from "./storyContainer"
+import RadioButtonGroupWithTitle, { RadioButtonGroupProps } from "../../src/components/radioButtonGroupWithTitle"
+
+const onChange = () => action("onChange")
+const initialValue = "B"
+
+export default {
+  title: "Radio Button Group with Title",
+  component: RadioButtonGroupWithTitle,
+  args: {
+    storyName: "",
+    title: "Radio Group",
+    value: initialValue,
+    checked: false,
+    onChange: (e) => {
+      onChange()(e)
+    },
+  },
+  argTypes: {
+    storyName: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+}
+
+interface Props extends StoryProps<JSX.Element>, RadioButtonGroupProps {}
+
+const Template: FC<Props> = (args) => {
+  return (
+      <>
+    <div className="text-2xl mb-20">{args.title}</div>
+        <RadioButtonGroupWithTitle
+          {...args}
+        />
+      </>
+    
+  )
+}
+
+export const Standard = Template.bind({})
+Standard.args = {
+    required: true,
+  storyName: "Standard",
+  radioInputs: [{name: "radioButtonGroupWithTitle", value: initialValue,
+  checked: false,
+  onChange: (e) => {
+    onChange()(e)
+  }, renderLabel:() => "labelgff fgfgdg"}, {name: "radioButtonGroupWithTitle", value: initialValue,
+  checked: false,
+  onChange: (e) => {
+    onChange()(e)
+  }, renderLabel:() => "label"}, {name: "radioButtonGroupWithTitle", value: initialValue,
+  checked: false,
+  onChange: (e) => {
+    onChange()(e)
+  }, renderLabel:() => "label"}, {name: "radioButtonGroupWithTitle", value: initialValue,
+  checked: false,
+  onChange: (e) => {
+    onChange()(e)
+  }, renderLabel:() => "label"}, {name: "radioButtonGroupWithTitle", value: initialValue,
+  checked: false,
+  onChange: (e) => {
+    onChange()(e)
+  }, renderLabel:() => "label"}, {name: "radioButtonGroupWithTitle", value: initialValue,
+  checked: false,
+  onChange: (e) => {
+    onChange()(e)
+  }, renderLabel:() => "label"}]
+}

--- a/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
+++ b/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
@@ -83,3 +83,9 @@ Required.args = {
   storyName: "Required",
   required: true,
 }
+
+export const WithErrorMessage = Template.bind({})
+WithErrorMessage.args = {
+  storyName: "With error message",
+  error: "Error message",
+}

--- a/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
+++ b/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
@@ -13,19 +13,36 @@ export default {
   args: {
     storyName: "",
     title: "Radio Group",
-    radioInputs: [{name: "radioButtonGroupWithTitle", value: "A",
-  checked: false,
-  onChange: (e) => {
-    onChange()(e)
-  }, renderLabel:() => "option 1"}, {name: "radioButtonGroupWithTitle", value: "B",
-  checked: false,
-  onChange: (e) => {
-    onChange()(e)
-  }, renderLabel:() => "option 2"}, {name: "radioButtonGroupWithTitle", value: "C",
-  checked: false,
-  onChange: (e) => {
-    onChange()(e)
-  }, renderLabel:() => "option 3"}]
+    radioInputs: 
+    [
+        {
+            name: "radioButtonGroupWithTitle", 
+            value: "A",
+            checked: false,
+            onChange: (e) => {
+                onChange()(e)
+            }, 
+            renderLabel:() => "option 1"
+        }, 
+        {
+            name: "radioButtonGroupWithTitle", 
+            value: "B",
+            checked: false,
+            onChange: (e) => {
+                onChange()(e)
+            }, 
+            renderLabel:() => "option 2"
+        }, 
+        {   
+            name: "radioButtonGroupWithTitle", 
+            value: "C",
+            checked: false,
+            onChange: (e) => {
+                onChange()(e)
+            }, 
+            renderLabel:() => "option 3"
+        }
+    ]
   },
   argTypes: {
     storyName: {

--- a/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
+++ b/.storybook/stories/radioButtonGroupWithTitle.stories.tsx
@@ -22,7 +22,9 @@ export default {
             onChange: (e) => {
                 onChange()(e)
             }, 
-            renderLabel:() => "option 1"
+            renderLabel:() => "option 1",
+            disabled: true,
+            error: "test"
         }, 
         {
             name: "radioButtonGroupWithTitle", 

--- a/src/components/radioButtonGroupWithTitle.tsx
+++ b/src/components/radioButtonGroupWithTitle.tsx
@@ -6,18 +6,20 @@ import Label from "./fieldHelpers/label"
 interface Props {
   title: string
   required?: boolean
+  disabled?: boolean
   radioInputs: RadioButtonProps[]
 }
 
 function RadioButtonGroup({
   title,
   required = false,
+  disabled = false,
   radioInputs,
 }: Props): ReactElement {
   return (
     <div className="w-12/12">
       <Label fieldName={title} required={required} />
-      <div className="flex w-12/12 justify-between">
+      <div className="flex justify-between">
         {radioInputs.map((radioInput, index) => (
           <RadioButton
             key={index}
@@ -26,7 +28,7 @@ function RadioButtonGroup({
             value={radioInput.value}
             checked={radioInput.checked}
             renderLabel={radioInput.renderLabel}
-            labelPosition={radioInput.labelPosition}
+            disabled={disabled}
           />
         ))}
       </div>

--- a/src/components/radioButtonGroupWithTitle.tsx
+++ b/src/components/radioButtonGroupWithTitle.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from "react"
+import React, { FC, ReactElement } from "react"
 
 import RadioButton, { RadioButtonProps } from "./radioButton"
+import WithValidationError from "./fieldHelpers/withValidationError"
 import Label from "./fieldHelpers/label"
 
 interface Props {
@@ -8,15 +9,17 @@ interface Props {
   required?: boolean
   disabled?: boolean
   radioInputs: RadioButtonProps[]
+  error?: string
 }
 
-function RadioButtonGroup({
+const RadioButtonGroup: FC<Props> = ({
   title,
   required = false,
   disabled = false,
   radioInputs,
-}: Props): ReactElement {
-  return (
+  error,
+}): ReactElement => {
+  const renderInputs = (hasError) => (
     <div className="w-12/12">
       <Label fieldName={title} required={required} />
       <div className="flex justify-between">
@@ -24,15 +27,18 @@ function RadioButtonGroup({
           <RadioButton
             key={index}
             name={radioInput.name}
-            onChange={radioInput.onChange}
-            value={radioInput.value}
-            checked={radioInput.checked}
-            renderLabel={radioInput.renderLabel}
             disabled={disabled}
+            error={hasError}
+            {...radioInput}
           />
         ))}
       </div>
     </div>
+  )
+  return (
+    <WithValidationError error={error}>
+      {(hasError) => renderInputs(hasError)}
+    </WithValidationError>
   )
 }
 

--- a/src/components/radioButtonGroupWithTitle.tsx
+++ b/src/components/radioButtonGroupWithTitle.tsx
@@ -4,11 +4,13 @@ import RadioButton, { RadioButtonProps } from "./radioButton"
 import WithValidationError from "./fieldHelpers/withValidationError"
 import Label from "./fieldHelpers/label"
 
+type RadioInputProps = Omit<RadioButtonProps, "error" | "disabled">
+
 interface Props {
   title: string
   required?: boolean
   disabled?: boolean
-  radioInputs: RadioButtonProps[]
+  radioInputs: RadioInputProps[]
   error?: string
 }
 
@@ -22,14 +24,13 @@ const RadioButtonGroup: FC<Props> = ({
   const renderInputs = (hasError) => (
     <div className="w-12/12">
       <Label fieldName={title} required={required} />
-      <div className="flex justify-between">
+      <div className="flex">
         {radioInputs.map((radioInput, index) => (
           <RadioButton
             key={index}
-            name={radioInput.name}
+            {...radioInput}
             disabled={disabled}
             error={hasError}
-            {...radioInput}
           />
         ))}
       </div>

--- a/src/components/radioButtonGroupWithTitle.tsx
+++ b/src/components/radioButtonGroupWithTitle.tsx
@@ -1,0 +1,38 @@
+import React, { ReactElement } from "react"
+
+import RadioButton, { RadioButtonProps } from "./radioButton"
+import Label from "./fieldHelpers/label"
+
+interface Props {
+  title: string
+  required?: boolean
+  radioInputs: RadioButtonProps[]
+}
+
+function RadioButtonGroup({
+  title,
+  required = false,
+  radioInputs,
+}: Props): ReactElement {
+  return (
+    <div className="w-12/12">
+      <Label fieldName={title} required={required} />
+      <div className="flex w-12/12 justify-between">
+        {radioInputs.map((radioInput, index) => (
+          <RadioButton
+            key={index}
+            name={radioInput.name}
+            onChange={radioInput.onChange}
+            value={radioInput.value}
+            checked={radioInput.checked}
+            renderLabel={radioInput.renderLabel}
+            labelPosition={radioInput.labelPosition}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default RadioButtonGroup
+export { Props as RadioButtonGroupProps }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import Slider from "./components/slider"
 import Select from "./components/select"
 import RangeSelect from "./components/rangeSelect"
 import RangeInput from "./components/rangeInput"
+import RadioButtonGroupWithTitle from "./components/radioButtonGroupWithTitle"
 import RadioButton from "./components/radioButton"
 import PreviewCard from "./components/previewCard/index"
 import Pill from "./components/pill"
@@ -68,6 +69,7 @@ export {
   Select,
   Checkbox,
   RadioButton,
+  RadioButtonGroupWithTitle,
   WithLabel,
   WithValidationError,
   useModal,


### PR DESCRIPTION
References [CAR-9534](https://autoricardo.atlassian.net/browse/CAR-9534)
Related PR : https://github.com/carforyou/carforyou-listings-web/pull/4030

Currently we dont have a component that returns a group of `RadioButton` with a global title. It could be useful in some cases, for example, to solve the issue of the related PR linked above.

In case this PR is approved, I'll create a task to replace the current occurences