### PR TITLE
fix: path to types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     "typescript": "4.3.5"
   },
   "sideEffects": false,
-  "main": "pkg/cjs/index.js",
-  "module": "pkg/esm/index.js",
-  "types": "pkg/types/index.d.ts",
+  "main": "./pkg/cjs/index.js",
+  "module": "./pkg/esm/index.js",
+  "types": "./pkg/types/src/index.d.ts",
   "files": [
     "pkg/**/*",
     "assets/**/*"

--- a/package.json
+++ b/package.json
@@ -81,8 +81,9 @@
     "typescript": "4.3.5"
   },
   "sideEffects": false,
-  "main": "./pkg/cjs/index.js",
-  "module": "./pkg/esm/index.js",
+  "main": "pkg/cjs/index.js",
+  "module": "pkg/esm/index.js",
+  "types": "pkg/types/index.d.ts",
   "files": [
     "pkg/**/*",
     "assets/**/*"


### PR DESCRIPTION
It was not possible to open type definitions or autocomplete the props in your IDE because the path was missing in package.json